### PR TITLE
chore(sync): add org sync config

### DIFF
--- a/.github/sync-config.yml
+++ b/.github/sync-config.yml
@@ -1,0 +1,17 @@
+sync:
+  files:
+    merge:
+      - path: "CONTRIBUTING.md"
+        strategy: "markdown"
+        sections:
+          - action: "after"
+            heading: "Prerequisites"
+            content: |
+              ### SAI Monorepo Structure
+
+              For the SAI project specifically:
+
+              - Each plugin is in its own top-level directory
+              - Test individual plugins: `claude --plugin-dir {plugin-name}/`
+              - Plugin-specific changes modify files in `{plugin-name}/`
+              - Monorepo-wide changes modify root files (README.md, CLAUDE.md, etc.)


### PR DESCRIPTION
## Motivation

Org file sync (PR #6) replaces `CONTRIBUTING.md` entirely, removing the SAI-specific "SAI Monorepo Structure" section. The new markdown section merge feature in the `.github` repo allows repos to preserve custom sections during sync.

## Implementation information

Add `.github/sync-config.yml` with a markdown merge config for `CONTRIBUTING.md`:

- `strategy: "markdown"` with `action: "after"` on heading `"Prerequisites"`
- Inserts the "SAI Monorepo Structure" section after Prerequisites ends
- Org sync will apply the template as base, then merge in the custom section

## Supporting documentation

- smykla-skalski/sai#6 — the sync PR that removes the custom section
- smykla-skalski/.github — markdown section merge feature

> Changelog: skip