### PR TITLE
feat(staff-code-review): add GitHub review posting

### DIFF
--- a/claude/staff-code-review/.claude-plugin/plugin.json
+++ b/claude/staff-code-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "staff-code-review",
   "description": "Staff-engineer-level code review evaluating architectural alignment, system-level implications, failure modes, performance, scalability, observability, security, and cross-team impact.",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "author": {
     "name": "Smykla Skalski Labs"
   },

--- a/claude/staff-code-review/skills/staff-code-review/SKILL.md
+++ b/claude/staff-code-review/skills/staff-code-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: staff-code-review
 description: Staff-engineer-level code review that goes beyond correctness to evaluate architectural alignment, system-level implications, failure modes, performance, scalability, backward compatibility, observability, security, and cross-team impact. Use when reviewing a PR (URL or diff), analyzing code changes for architectural fitness, or when the user asks for a thorough/staff-level/senior review of code changes. Triggers on "review this PR", "review these changes", "staff review", "thorough code review", sharing a GitHub PR URL for review, or asking about the architectural impact of changes.
-allowed-tools: Agent, Bash, Read
+allowed-tools: Agent, Bash, Read, Write
 ---
 
 # Staff-Level Code Review
@@ -219,9 +219,79 @@ After all agents return, merge findings and:
 5. **Note where research changed finding severity** — e.g., "47 callers makes this breaking change blocking" or "no callers found, downgrading to suggestion". Cite specific codebase evidence (file paths, caller counts, pattern matches) that grounded the assessment.
 6. **Validate blocking findings** — for each blocking issue, verify the evidence by re-reading the relevant code. If evidence is ambiguous or based on assumptions, downgrade to `question:` and request clarification from the author. Repeat until every blocking issue has verified codebase evidence.
 
+### Save Review
+
+After synthesis completes, persist the full review markdown for reference.
+
+1. Resolve the persistent data directory:
+   ```bash
+   DATA_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/sai/staff-code-review/reviews"
+   mkdir -p "$DATA_DIR"
+   ```
+2. Determine the PR number:
+   - If input was a GitHub PR URL: extract number via URL parsing (the `/pull/{number}` segment)
+   - Otherwise: use `"local"` as prefix
+3. Generate timestamp: `date -u +%Y%m%dT%H%M%S`
+4. Save the complete review markdown to `${DATA_DIR}/{pr_number}-{timestamp}.md` using the Write tool
+5. Report the saved file path to the user
+
+### Post to GitHub
+
+**Skip this phase entirely if the input was NOT a GitHub PR URL.**
+
+Create a PENDING (draft) review on the PR with inline comments. The review is invisible to the PR author until manually submitted from GitHub's UI — you can edit, delete, or add comments before publishing.
+
+1. Parse owner, repo, and PR number from the URL (e.g., `https://github.com/{owner}/{repo}/pull/{number}`)
+
+2. Extract inline comments from the saved review file using the parsing script:
+   ```bash
+   COMMENTS_JSON=$(python3 "${CLAUDE_SKILL_DIR}/scripts/parse_review_comments.py" "$REVIEW_FILE")
+   ```
+   The script extracts comments with `*Location:*` annotations and filters to: all blockers, all issues, up to 5 suggestions, and up to 3 praises. Questions, thoughts, and nits are excluded from inline comments.
+
+3. Extract the Review Summary section from the review markdown as the top-level review body. Include the verdict line and blocking/non-blocking counts.
+
+4. Build the API payload and submit:
+   ```bash
+   python3 -c "
+   import json, sys
+   body = sys.argv[1]
+   comments = json.loads(sys.argv[2])
+   for c in comments:
+       c.setdefault('side', 'RIGHT')
+   payload = {'body': body, 'comments': comments}
+   print(json.dumps(payload))
+   " "$REVIEW_BODY" "$COMMENTS_JSON" | gh api "repos/${OWNER}/${REPO}/pulls/${PR_NUMBER}/reviews" --input -
+   ```
+   The payload omits the `event` field, which makes the API create a PENDING/draft review.
+
+5. Report to the user:
+   - Review URL and comment count
+   - Remind them the review is **PENDING** — they must open GitHub and click "Submit review" to publish
+   - They can edit or delete individual comments before submitting
+
+6. If the API call fails:
+   - Most common cause: a file path or line number in a comment doesn't match the PR diff (GitHub requires the line to be visible in the diff)
+   - Report the error and the saved review file path so the user can inspect and retry
+
+**Do NOT re-run the API call after it exits 0.** The review creation is atomic — all comments are attached in a single request.
+
 ## Comment format
 
-Use conventional comments with explicit severity. Every comment follows this structure:
+Use conventional comments with explicit severity. Every comment **MUST** follow this exact two-line structure — the parsing script depends on it for GitHub review posting:
+
+```
+**{label}:** {message}
+*Location:* `{path/to/file}:{line_number}`
+```
+
+Rules:
+- `**{label}:**` on the first line, followed by the message on the same line (may wrap to additional lines)
+- `*Location:*` on its own line immediately after the message, with backtick-wrapped `path:line`
+- Path must be relative to repo root, no leading `./`
+- Line number must reference the exact line in the current file (not the diff)
+- Every file-specific comment MUST have a `*Location:*` line — comments without location cannot be posted as inline GitHub review comments
+- General observations (cross-cutting, overall praise) that don't map to a specific line may omit `*Location:*` — these go in the review body instead
 
 <example>
 Input: Finding a missing timeout on an HTTP call in `pkg/client/fetch.go:42`.

--- a/claude/staff-code-review/skills/staff-code-review/scripts/parse_review_comments.py
+++ b/claude/staff-code-review/skills/staff-code-review/scripts/parse_review_comments.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Extract review comments from staff-code-review markdown.
+
+Parses conventional comments with severity labels and file:line
+locations, filters per posting rules, and outputs a JSON array
+compatible with the GitHub PR review API comments format.
+
+Usage:
+    ./parse_review_comments.py <review_file>
+    ./parse_review_comments.py -   # read from stdin
+
+Output (stdout): JSON array of comment objects:
+    [{"path": "f.go", "line": 42, "body": "...", "side": "RIGHT"}]
+
+Exit codes:
+    0  Success (may output empty array)
+    1  Runtime error
+    2  Usage/input error
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+VALID_LABELS: Final[frozenset[str]] = frozenset(
+    {"blocking", "issue", "question", "suggestion", "thought", "nit", "praise"},
+)
+
+ALWAYS_INCLUDE: Final[frozenset[str]] = frozenset({"blocking", "issue"})
+SAMPLED_LIMITS: Final[dict[str, int]] = {"suggestion": 5, "praise": 3}
+ALWAYS_EXCLUDE: Final[frozenset[str]] = frozenset({"question", "thought", "nit"})
+
+# ---------------------------------------------------------------------------
+# Regex patterns (precompiled)
+# ---------------------------------------------------------------------------
+
+# Matches a conventional comment block:
+#   **label:** message text (possibly multiline)
+#   *Location:* `path/to/file:line`
+#
+# The message capture is non-greedy and stops at the *Location:* line.
+COMMENT_RE: Final[re.Pattern[str]] = re.compile(
+    r"\*\*(?P<label>" + "|".join(VALID_LABELS) + r"):\*\*\s*"
+    r"(?P<message>.+?)\n"
+    r"\s*\*Location:\*\s*`(?P<path>[^`:\s]+):(?P<line>\d+)`",
+    re.DOTALL,
+)
+
+# Leading ./ in paths
+LEADING_DOT_SLASH_RE: Final[re.Pattern[str]] = re.compile(r"^\./")
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ReviewComment:
+    """Single conventional comment extracted from review markdown."""
+
+    label: str
+    message: str
+    path: str
+    line: int
+
+
+# ---------------------------------------------------------------------------
+# Parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_comments(text: str) -> list[ReviewComment]:
+    """Extract all conventional comments with location from review markdown."""
+    results: list[ReviewComment] = []
+    for m in COMMENT_RE.finditer(text):
+        path = LEADING_DOT_SLASH_RE.sub("", m.group("path").strip())
+        line = int(m.group("line"))
+        if line < 1:
+            continue
+        results.append(
+            ReviewComment(
+                label=m.group("label"),
+                message=m.group("message").strip(),
+                path=path,
+                line=line,
+            ),
+        )
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Filtering
+# ---------------------------------------------------------------------------
+
+
+def filter_comments(comments: list[ReviewComment]) -> list[ReviewComment]:
+    """Apply posting rules: all blockers/issues, limited suggestions/praises."""
+    result: list[ReviewComment] = []
+    counts: dict[str, int] = {}
+    for c in comments:
+        if c.label in ALWAYS_EXCLUDE:
+            continue
+        if c.label in ALWAYS_INCLUDE:
+            result.append(c)
+        elif c.label in SAMPLED_LIMITS:
+            current = counts.get(c.label, 0)
+            if current < SAMPLED_LIMITS[c.label]:
+                result.append(c)
+                counts[c.label] = current + 1
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+
+
+def to_github_comments(
+    comments: list[ReviewComment],
+) -> list[dict[str, str | int]]:
+    """Convert filtered comments to GitHub review API comment format."""
+    seen: set[tuple[str, int, str]] = set()
+    result: list[dict[str, str | int]] = []
+    for c in comments:
+        body = f"**{c.label}:** {c.message}"
+        key = (c.path, c.line, body)
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append({"path": c.path, "line": c.line, "body": body, "side": "RIGHT"})
+    return result
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint: parse review markdown, output filtered comments."""
+    parser = argparse.ArgumentParser(
+        description="Extract review comments for GitHub PR review",
+    )
+    parser.add_argument(
+        "review_file",
+        help="Path to review markdown file (or - for stdin)",
+    )
+    args = parser.parse_args(argv)
+
+    if args.review_file == "-":
+        text = sys.stdin.read()
+    else:
+        path = Path(args.review_file)
+        if not path.is_file():
+            print(f"Error: file not found: {path}", file=sys.stderr)
+            return 2
+        text = path.read_text(encoding="utf-8", errors="replace")
+
+    comments = parse_comments(text)
+    filtered = filter_comments(comments)
+    github_comments = to_github_comments(filtered)
+    json.dump(github_comments, sys.stdout, indent=2)
+    print()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Motivation

Staff-code-review generates structured markdown but doesn't post it to GitHub. Reviewers had to manually copy findings into PR comments. This adds automated posting as a PENDING (draft) review with inline file comments, so the reviewer can edit/approve before publishing.

## Implementation information

Three changes:

1. **`parse_review_comments.py`** — Python script that parses review markdown, extracts conventional comments (`**label:** message` + `*Location:* \`path:line\``) and filters them: all blockers/issues, up to 5 suggestions, up to 3 praises. Outputs JSON array for GitHub review API.

2. **SKILL.md new phases** — Two phases after synthesis:
   - *Save Review*: persists full review to `~/.local/share/sai/staff-code-review/reviews/{pr}-{timestamp}.md`
   - *Post to GitHub*: creates PENDING review via `gh api` with filtered inline comments. User edits and submits from GitHub UI.

3. **Comment format tightened** — Explicit `*Location:*` requirement with repo-relative paths so the parsing script works reliably.

Always creates PENDING reviews (invisible to PR author until manually submitted). No cross-plugin dependencies — calls `gh api` directly.

> Changelog: feat(staff-code-review): add GitHub review posting with PENDING draft reviews