### PR TITLE
docs(review-claude-md): link rule refs

### DIFF
--- a/claude/review-claude-md/.claude-plugin/plugin.json
+++ b/claude/review-claude-md/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "review-claude-md",
   "description": "Audit and fix CLAUDE.md files using tiered binary checklist",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "author": {
     "name": "Smykla Skalski Labs"
   },

--- a/claude/review-claude-md/skills/review-claude-md/SKILL.md
+++ b/claude/review-claude-md/skills/review-claude-md/SKILL.md
@@ -34,7 +34,7 @@ Read [references/rubric.md](references/rubric.md) for the full tiered checklist 
 
 1. Identify target repo root (from argument or cwd)
 2. Find all CLAUDE.md files: root, `.claude/CLAUDE.md`, `CLAUDE.local.md`, subdirectories
-3. Find `.claude/rules/*.md` files
+3. Find [.claude/rules/](.claude/rules/) `*.md` files
 4. Note git-tracked vs gitignored status
 
 ### Phase 2: Codebase Context
@@ -42,7 +42,7 @@ Read [references/rubric.md](references/rubric.md) for the full tiered checklist 
 Spawn an `Explore` agent to scan the target repository. Pass the agent: the repo root path.
 
 Agent reads: Makefile, package.json, Cargo.toml, go.mod, pyproject.toml, CI configs (.github/workflows/, .gitlab-ci.yml), README.md, test configs (jest.config, pytest.ini, vitest.config), lint configs (.eslintrc, biome.json, .prettierrc, rustfmt.toml).
-Also reads: top-level directory structure, `git log --oneline -20`, `.claude/rules/` contents.
+Also reads: top-level directory structure, `git log --oneline -20`, [.claude/rules/](.claude/rules/) contents.
 
 Agent returns ONLY a structured summary with these fields:
 
@@ -50,7 +50,7 @@ Agent returns ONLY a structured summary with these fields:
 - Test framework and test commands
 - Lint/format tool and commands
 - CI provider and workflow names
-- Existing `.claude/rules/` files and their topics
+- Existing [.claude/rules/](.claude/rules/) files and their topics
 - Commit message convention observed
 - README sections that overlap with CLAUDE.md content
 
@@ -102,7 +102,7 @@ If `--score-only` was NOT passed (`--fix` mode, the default):
 
 1. Address every failing Critical and Important check
 2. Re-read [references/sources.md](references/sources.md) for rewriting principles before editing because fixes that violate source guidelines create new failures
-3. Create `.claude/rules/` files if root exceeds 150 lines
+3. Create [.claude/rules/](.claude/rules/) files if root exceeds 150 lines
 4. Target: under 150 lines (ideally 50-100 for root)
 
 ### Phase 8: Final Report

--- a/claude/review-claude-md/skills/review-claude-md/references/output-format.md
+++ b/claude/review-claude-md/skills/review-claude-md/references/output-format.md
@@ -45,6 +45,6 @@
 ...
 
 ### Rules Files Created
-- .claude/rules/<name>.md — <purpose>
+- [.claude/rules/<name>.md](.claude/rules/<name>.md) — <purpose>
 ...
 ```

--- a/claude/review-claude-md/skills/review-claude-md/references/rubric.md
+++ b/claude/review-claude-md/skills/review-claude-md/references/rubric.md
@@ -38,7 +38,7 @@
 | I6  | Bullets over paragraphs throughout                               | Official Best Practices, Maxitect |
 | I7  | Pointers over copies (file:line refs, not embedded code blocks)  | HumanLayer                        |
 | I8  | Style rules only where they differ from language defaults        | Official Best Practices           |
-| I9  | Modularized with `.claude/rules/` if root file is complex        | Official Memory Docs              |
+| I9  | Modularized with [.claude/rules/](.claude/rules/) if root file is complex | Official Memory Docs       |
 
 **How to evaluate:** For I1, check that the architecture section explains how components interact, not just where files live. For I3, gotchas must be specific to this project — "always run migrations before tests" qualifies, "handle errors gracefully" does not. For I7, flag any embedded code block over 5 lines that could be replaced with a file reference.
 

--- a/claude/review-claude-md/skills/review-claude-md/references/sources.md
+++ b/claude/review-claude-md/skills/review-claude-md/references/sources.md
@@ -33,7 +33,7 @@ These principles guide both scoring and fixing:
 - **Pointers over copies**: Use `file:line` references, not embedded code snippets (HumanLayer)
 - **Alternatives, not negatives**: "Use Y instead of X" not "Never use X" (Arize)
 - **No README duplication**: CLAUDE.md is for AI-operational context, not human onboarding (Official)
-- **Modularize with rules/**: Use `.claude/rules/` for detailed topic files, keep root CLAUDE.md lean (Official)
+- **Modularize with rules/**: Use [.claude/rules/](.claude/rules/) for detailed topic files, keep root CLAUDE.md lean (Official)
 - **Use hooks for deterministic actions**: "Unlike CLAUDE.md instructions which are advisory, hooks are deterministic" (Official)
 - **The "First 5 Minutes" Test**: Could a new dev build, test, and contribute reading only this file? (Community)
 - **Treat it like code**: Review when things go wrong, prune regularly (Official)


### PR DESCRIPTION
## Motivation

User feedback: in the review-claude-md skill, references to `.claude/rules/` should always render as markdown links, not inline code spans.

## Implementation information

- Replaced backticked `.claude/rules/` paths with `[.claude/rules/](.claude/rules/)` markdown links across SKILL.md, rubric.md, sources.md, output-format.md
- Bumped plugin version to 1.7.1

## Supporting documentation

None

> Changelog: skip