### PR TITLE
feat(staff-code-review): use council personas

### DIFF
--- a/claude/staff-code-review/.claude-plugin/plugin.json
+++ b/claude/staff-code-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "staff-code-review",
   "description": "Staff-engineer-level code review evaluating architectural alignment, system-level implications, failure modes, performance, scalability, observability, security, and cross-team impact.",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "author": {
     "name": "Smykla Skalski Labs"
   },

--- a/claude/staff-code-review/README.md
+++ b/claude/staff-code-review/README.md
@@ -6,9 +6,14 @@ Staff-engineer-level code review that goes beyond correctness to evaluate archit
 
 - **Triage pass** — six mental model questions (Tanya Reilly) before line-by-line review
 - **Codebase research** — caller counts, existing patterns, test coverage, git history, ADR context
-- **Parallel deep review** — three specialized agents: Architecture & Design, Reliability & Operations, Security & Dependencies
+- **Parallel deep review with council personas** — seven specialized agents, each routed to a council persona that owns the lens (Evans for Architecture, Hebert for Reliability, Willison for Security, **Gregg for Performance**, Siracusa for Backward Compat, antirez for Conventions, tef for Dead Code). Falls back to `general-purpose` if the council plugin is not installed.
+- **Translation pass** — persona-format reviews are converted to conventional comments without losing technical content
 - **Conventional comments** — `blocking:`, `issue:`, `question:`, `suggestion:`, `thought:`, `nit:`, `praise:`
 - **Design doc detection** — flags PRs that should have had an RFC/design doc first
+
+## Optional dependency
+
+For maximum review quality, install the [council](../council/) plugin alongside this one. Without it, Pass 2 still runs — it just uses generic `general-purpose` agents instead of opinionated personas.
 
 ## Usage
 

--- a/claude/staff-code-review/skills/staff-code-review/SKILL.md
+++ b/claude/staff-code-review/skills/staff-code-review/SKILL.md
@@ -88,30 +88,52 @@ Output:
 
 ### Pass 2: Deep review (parallel)
 
-Spawn parallel Agent subagents (subagent_type: "general-purpose") for each dimension group. Each agent gets the diff/files **and the Research Brief from Pass 1.5**. This parallelism is important for speed on large PRs.
+Spawn parallel Agent subagents — one per dimension group — using the **council persona** mapped to that dimension (see Persona dispatch table below). Each agent gets the diff/files **and the Research Brief from Pass 1.5**. This parallelism is important for speed on large PRs.
 
 Read [references/review-dimensions.md](references/review-dimensions.md) before distributing work to agents — it contains detailed checklists for each dimension.
 
-**Agent 1: Architecture & Design**
+#### Persona dispatch
+
+| Dimension | Primary persona | Fallback |
+|---|---|---|
+| Architecture & Design | `council:evans-ddd-reviewer` | `general-purpose` |
+| Reliability & Operations | `council:hebert-resilience-reviewer` | `general-purpose` |
+| Security & Dependencies | `council:ai-quality-advisor` | `general-purpose` |
+| Performance & Scalability | `council:gregg-perf-reviewer` | `general-purpose` |
+| Backward Compatibility | `council:siracusa-mac-critic` | `general-purpose` |
+| Convention Conformance & Code Reuse | `council:antirez-simplicity-reviewer` | `general-purpose` |
+| Dead Code Detection | `council:tef-deletability-reviewer` | `general-purpose` |
+
+**Spawn protocol:**
+1. Try `subagent_type: "council:<persona>"` first.
+2. If the spawn fails because the subagent type is unknown (council plugin not installed), retry with `subagent_type: "general-purpose"` and prepend the dimension's checklist directly to the prompt instead of relying on the persona system prompt.
+3. The persona will respond in its own native output format (e.g., `## Brendan Gregg review` with five sections). **Do not** ask personas to emit conventional-comment format — that loses their voice. Pass 2.5 translates their output into the format required by `parse_review_comments.py`.
+
+When spawning a council persona, the prompt MUST include:
+- The PR diff and Research Brief (verbatim).
+- The dimension checklist from this SKILL.md (so the persona knows which axes to cover).
+- An explicit instruction: *"Apply your lens to this PR. Stay in character. Use your normal output format. For each finding, name a specific file and line number from the diff."*
+
+**Agent 1: Architecture & Design** — `council:evans-ddd-reviewer` (Eric Evans lens: ubiquitous language, bounded contexts, model integrity)
 - Architectural alignment: does this introduce a pattern that will be copied? Does it violate existing conventions?
 - API design: deprecation path, error contract stability, surface area minimization
 - Data model evolution: schema impact on existing records, unbounded growth, denormalization
 - Cross-team impact: which teams consume affected APIs? Paved road drift?
 - **Use Research Brief:** Check "Existing Patterns" for convention violations. Use "Callers & Consumers" to assess cross-team impact with real caller counts. Reference "Architecture Context" for ADR compliance.
 
-**Agent 2: Reliability & Operations**
+**Agent 2: Reliability & Operations** — `council:hebert-resilience-reviewer` (Fred Hebert lens: operability, supervision trees, controlled-burn failure)
 - Failure mode analysis: what happens when downstream is unavailable? Blast radius? Retry idempotency? Race conditions?
 - Observability: can you diagnose a 3am outage? Structured logging with correlation IDs? Metrics for new paths? Alertability?
 - Migration/rollback safety: backward-compatible with current version? Rollback procedure? Feature flags for disable without rollback? Expand-and-contract for schema changes? Progressive rollout path?
 - **Use Research Brief:** Use "Callers & Consumers" to quantify blast radius (e.g., "47 callers affected" vs "unused internal helper"). Check "Related Tests" for coverage gaps on critical paths. Use "Git History" to calibrate risk — high-volatility areas deserve more scrutiny.
 
-**Agent 3: Security & Dependencies**
+**Agent 3: Security & Dependencies** — `council:ai-quality-advisor` (Simon Willison lens: prompt injection, sandboxed tools, eval-driven security; closest fit — council has no pure-security persona)
 - Security: input validation, auth on all endpoints, secrets in code/logs, PII exposure, injection risks, crypto choices
 - Dependency management: license, CVEs, maintenance status, transitive footprint, supply chain risk
 - Could this be done without the new dependency?
 - **Use Research Brief:** Use "Callers & Consumers" to trace data flow through changed functions — identify where untrusted input enters. Check "Existing Patterns" for security practice consistency (e.g., does similar code validate inputs?). Reference "Architecture Context" for security-related ADRs.
 
-**Agent 4: Performance & Scalability**
+**Agent 4: Performance & Scalability** — `council:gregg-perf-reviewer` (Brendan Gregg lens: USE method, profile in prod, BPF, systems perf)
 
 Read [references/performance-scalability.md](references/performance-scalability.md) before starting this analysis.
 
@@ -138,7 +160,7 @@ Severity calibration:
 
 - **Use Research Brief:** Use "Callers & Consumers" to determine if changed code is on a hot path (high caller count = higher severity). Check "Related Tests" for perf test coverage. Use "Git History" to identify recently optimized areas where the PR may regress. Reference "Existing Patterns" to check if the codebase has established patterns for caching, batching, or connection management that the PR should follow.
 
-**Agent 5: Backward Compatibility**
+**Agent 5: Backward Compatibility** — `council:siracusa-mac-critic` (John Siracusa lens: AppKit/Mac platform critique with strong backwards-compat sensibility; reads change-as-contract)
 
 Read [references/backward-compatibility.md](references/backward-compatibility.md) before starting this analysis.
 
@@ -162,7 +184,7 @@ Severity calibration:
 
 - **Use Research Brief:** Use "Callers & Consumers" to count affected consumers and quantify blast radius — high caller count + breaking change = blocking, zero callers = downgrade severity. Check "Existing Patterns" for versioning/deprecation conventions the PR should follow. Reference "Architecture Context" for API contracts and compatibility policies. Use "Git History" to identify recent breaking changes that may compound with this one.
 
-**Agent 6: Convention Conformance & Code Reuse**
+**Agent 6: Convention Conformance & Code Reuse** — `council:antirez-simplicity-reviewer` (antirez lens: simplicity, anti-bloat, reuse-or-rewrite tradeoff)
 
 Read [references/convention-conformance.md](references/convention-conformance.md) before starting this analysis.
 
@@ -185,7 +207,7 @@ Severity calibration:
 
 - **Use Research Brief:** Use "Existing Patterns" as primary input — this is the core data for convention analysis. Grep for function/type names similar to what the PR introduces. Check "Callers & Consumers" to understand if the PR's new code will be called alongside existing code with different conventions (inconsistency risk). Reference "Architecture Context" for documented conventions in READMEs or ADRs.
 
-**Agent 7: Dead Code Detection**
+**Agent 7: Dead Code Detection** — `council:tef-deletability-reviewer` (tef lens: easy to delete, anti-naive-DRY, protocol over topology)
 
 Read [references/dead-code.md](references/dead-code.md) before starting this analysis.
 
@@ -207,7 +229,13 @@ Severity calibration:
 
 - **Use Research Brief:** Use "Callers & Consumers" as primary input — cross-reference every new/modified symbol against its caller count. Zero callers on a non-public, non-interface symbol = dead code. Check "Existing Patterns" for framework conventions that create indirect reachability. Use "Git History" to identify recently removed features whose cleanup may be incomplete.
 
-Each agent returns findings as conventional comments (see format below).
+Each persona returns findings in **its own native output format** (see [council/agents/](../../../../council/agents/) for each persona's required structure). Do not attempt to enforce conventional-comment format on the persona itself — Pass 2.5 handles translation. If the spawn used the `general-purpose` fallback, the prompt MUST instruct that agent to emit conventional-comment format directly (see "Comment format" below); skip Pass 2.5 for findings produced by fallback agents.
+
+### Pass 2.5: Translation
+
+Persona output is rich but not parseable. Convert each persona's review into the conventional-comment structure that `parse_review_comments.py` expects, without losing technical content.
+
+Read [references/persona-translator-prompt.md](references/persona-translator-prompt.md) before spawning the translator — it contains the full prompt, label-selection rules, formatting constraints, and failure-recovery behavior. The translator returns dimension-grouped conventional comments. Pass these to Synthesis.
 
 ### Synthesis
 
@@ -450,3 +478,4 @@ Flag (don't block, but strongly recommend) when the PR:
 - Backward compatibility deep reference: [references/backward-compatibility.md](references/backward-compatibility.md)
 - Convention conformance deep reference: [references/convention-conformance.md](references/convention-conformance.md)
 - Dead code detection deep reference: [references/dead-code.md](references/dead-code.md)
+- Persona translator prompt: [references/persona-translator-prompt.md](references/persona-translator-prompt.md)

--- a/claude/staff-code-review/skills/staff-code-review/references/persona-translator-prompt.md
+++ b/claude/staff-code-review/skills/staff-code-review/references/persona-translator-prompt.md
@@ -1,0 +1,63 @@
+# Persona Translator Prompt
+
+Use this prompt verbatim when spawning the Pass 2.5 translation agent. The translator converts council-persona reviews (in their native output format) into the conventional-comment structure that `parse_review_comments.py` expects, without losing technical content.
+
+## Spawn instructions
+
+Spawn a single `Agent` (subagent_type: `general-purpose`). Substitute `{persona reviews block}` with each persona's full output, separated by `---` delimiters and labeled with the dimension and persona name (e.g., `### Performance & Scalability — Brendan Gregg`).
+
+## Prompt
+
+```
+You are a review comment translator. You receive 1-7 persona reviews, each in the
+persona's native output format (e.g., "## Brendan Gregg review" with sections like
+"What concerns me", "What I'd ask before approving"). Your job: extract every
+actionable finding and rewrite it as a conventional comment block.
+
+PERSONA REVIEWS:
+<reviews>
+{persona reviews block}
+</reviews>
+
+OUTPUT FORMAT for each finding — emit nothing else:
+
+**{label}:** {one-sentence message}
+*Location:* `{path/to/file}:{line_number}`
+
+LABEL SELECTION (be strict):
+- blocking: security holes, race conditions, missing timeouts, N+1 queries,
+  resource leaks, breaking changes without migration, architectural violations
+  that will spread.
+- issue: correctness bugs, missing error handling on critical paths, incomplete
+  migration paths.
+- question: persona requested clarification before deciding ("What's the p99?",
+  "Have you off-CPU-flame-graphed it?").
+- suggestion: persona proposed an alternative approach with rationale.
+- thought: educational, non-blocking pattern note.
+- nit: trivial style/naming.
+- praise: persona explicitly called out good work.
+
+RULES:
+1. One finding = one block. Do not merge findings even if they share a file.
+2. Every finding MUST have a *Location:* line with `path:line`. If the persona
+   did not name a specific line, search the diff for the most plausible line and
+   cite it. If still ambiguous, mark the finding as "question:" and locate it on
+   the most relevant changed line.
+3. Preserve technical specifics: file paths, function names, caller counts,
+   metric names, the persona's actual evidence. Do NOT add information the
+   persona did not state.
+4. Strip persona voice scaffolding (e.g., "G'Day", "What I see", "Where I'd be
+   wrong"). Keep only the actionable finding text in the message.
+5. Keep messages under 280 characters. Staff engineers write tight prose.
+6. Group output by dimension heading (## Architecture & Design, ## Reliability
+   & Operations, etc.) so synthesis can consume them dimension-by-dimension.
+7. Emit nothing for the persona's "Where I'd be wrong" section unless it names
+   a concrete codebase risk.
+```
+
+## Failure recovery
+
+If the translator output is malformed (missing labels, missing locations on file-specific findings, malformed location syntax):
+
+1. Retry once with the same prompt plus the malformed output and the instruction "Fix the format violations and re-emit."
+2. If it still fails, fall back to including the raw persona output in the review markdown — synthesis can still reason over it, but `parse_review_comments.py` will skip un-parseable comments when posting to GitHub.


### PR DESCRIPTION
## Motivation

Generic Pass-2 agents drifted toward template output. Routing each
review dimension to an opinionated council persona surfaces sharper
findings — USE-method critiques from Gregg, supervision-tree concerns
from Hebert, anti-bloat from antirez — instead of safe, hedged prose.

## Implementation information

Pass 2 picks `council:<persona>` per dimension; falls back to
`general-purpose` if the council plugin is unavailable, so the skill
stays usable standalone.

Pass 2.5 (new) converts persona-native output (e.g. `## Brendan Gregg
review` with five sections) into the conventional-comment structure
`parse_review_comments.py` expects. Translator prompt lives in
`references/persona-translator-prompt.md` to keep SKILL.md under the
500-line guideline.

Persona mapping:

| Dimension | Persona |
|---|---|
| Architecture & Design | `evans-ddd-reviewer` |
| Reliability & Operations | `hebert-resilience-reviewer` |
| Security & Dependencies | `ai-quality-advisor` (Willison) |
| Performance & Scalability | `gregg-perf-reviewer` |
| Backward Compatibility | `siracusa-mac-critic` |
| Convention Conformance | `antirez-simplicity-reviewer` |
| Dead Code Detection | `tef-deletability-reviewer` |

Two weak fits worth flagging: council has no pure-security persona
(Willison is closest) and no native API/wire backward-compat persona
(Siracusa reads change-as-contract well but isn't a perfect match).

Alternatives considered and discarded:
- Hard dependency on council — rejected; fallback keeps the skill
  standalone-usable.
- Inline persona prompts inside `general-purpose` agents — rejected;
  duplicates council's deep-dossier infrastructure.
- Override format in spawn prompt to skip Pass 2.5 — rejected; loses
  the persona voice sections that justify using personas at all.

Bump `staff-code-review` plugin 1.6.0 -> 1.7.0.

> Changelog: feat(staff-code-review): use council personas

## Supporting documentation

None. Council personas already live in `claude/council/agents/`.