### PR TITLE
docs(copilot): fix plugin install guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,7 +6,7 @@ This repo has **no repo-level build, test, or lint entrypoint**. It is mostly Ma
 
 - Claude plugin smoke test: `claude --plugin-dir claude/{plugin-name}/`
 - Single-skill smoke run: `claude --plugin-dir claude/{plugin-name}/ -p "/{skill-name} test args"`
-- Copilot council package smoke test: `copilot plugin install /absolute/path/to/sai/plugins/council`, then run `/council ...` in Copilot CLI
+- Copilot package smoke test: use `copilot --plugin-dir /absolute/path/to/sai/claude/{plugin-name}` for the self-contained plugin packages under `claude/`, or `copilot --plugin-dir /absolute/path/to/sai/plugins/council` for council's dedicated bundle, then run the relevant slash command in Copilot CLI
 - For script-heavy skill changes, run the local checker/schema/smoke flow that belongs to that plugin rather than adding placeholder `mise`, `make`, or lint tasks
 
 ## Copilot plugin improvement loop
@@ -17,7 +17,7 @@ Use this full loop for behavior changes in `plugins/`, especially `plugins/counc
 2. If you are fixing runtime Copilot behavior, inspect real Copilot session artifacts under `~/.copilot/session-state/` and use unique `VALIDATE_*` tokens in smoke prompts so you can find the right session later.
 3. Make the behavior change across the whole surface, not just one file: `copilot-skills/.../SKILL.md`, any bundled `agents/*.agent.md`, `plugin.json`, and `README.md` when user-facing behavior changed.
 4. For any functional plugin change, bump that plugin’s `plugin.json` version in the same change.
-5. Refresh the local Copilot install with `copilot plugin install /absolute/path/to/sai/plugins/{plugin}` before validating.
+5. Load the local Copilot package with `copilot --plugin-dir /absolute/path/to/sai/claude/{plugin}` for the self-contained plugin packages, or `copilot --plugin-dir /absolute/path/to/sai/plugins/{plugin}` when a dedicated bundle exists, before validating.
 6. Use the cheapest practical model for repeated validation and smoke loops (typically `gpt-5-mini`). Only escalate to a stronger model when the issue is genuinely diagnosis-heavy or the cheaper model is failing to make progress.
 7. Run long Copilot validations in the background and actively observe them rather than blocking on one giant wrapper. If one case hangs, split validations into separate commands per case.
 8. Run Copilot smoke validations from the **real target repository/cwd**, not from `sai`, when behavior depends on surrounding repo context.
@@ -40,8 +40,8 @@ Use this full loop for behavior changes in `plugins/`, especially `plugins/counc
 ## High-level architecture
 
 - The repo has three delivery surfaces:
-  - `claude/` contains Claude Code plugins
-  - `plugins/` contains installable plugin packages for Copilot CLI and Codex-compatible flows
+  - `claude/` contains self-contained plugin packages for Claude Code and Copilot CLI marketplace installs
+  - `plugins/` contains Codex-compatible packages and special multi-surface bundles such as `plugins/council/`
   - `codex/` contains Codex skills and shared native agent definitions
 - Claude plugins are self-contained and use a strict discovery layout:
   - `claude/{plugin}/.claude-plugin/plugin.json`

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ A collection of Claude Code plugins and Codex skills for development workflows, 
 This monorepo contains independent plugins, each providing specialized capabilities:
 
 Repository layout:
-- `claude/` contains all Claude Code plugins.
+- `claude/` contains the self-contained plugin packages used by Claude Code and Copilot CLI marketplace installs.
 - `codex/` contains Codex/Codex Desktop skills and shared native agent definitions.
-- `plugins/` contains installable plugin packages and marketplace entrypoints for Copilot CLI and Codex-compatible plugin flows.
+- `plugins/` contains Codex-compatible packages and special multi-surface bundles such as `plugins/council/`.
 
 | Plugin                  | Description                                                                             | Installation Path      |
 |:------------------------|:----------------------------------------------------------------------------------------|:-----------------------|
@@ -47,22 +47,22 @@ Add the SAI marketplace, then install individual plugins:
 /plugin marketplace add git@github.com:smykla-skalski/sai.git
 
 # Install individual plugins
-/plugin install sai/ai-daily-digest
-/plugin install sai/council
-/plugin install sai/service-mesh-debug
+/plugin install ai-daily-digest@sai
+/plugin install council@sai
+/plugin install service-mesh-debug@sai
 
-# (Codex marketplace also provides /plugin install sai/council for Codex sessions)
-/plugin install sai/gh-review-comments
-/plugin install sai/git-clean-gone
-/plugin install sai/git-stage-hunk
-/plugin install sai/go-code-review
-/plugin install sai/humanize
-/plugin install sai/kubecon-cfp
-/plugin install sai/promptgen
-/plugin install sai/review-claude-md
-/plugin install sai/staff-code-review
-/plugin install sai/staff-resume
-/plugin install sai/test-writer
+# (Codex marketplace also provides /plugin install council@sai for Codex sessions)
+/plugin install gh-review-comments@sai
+/plugin install git-clean-gone@sai
+/plugin install git-stage-hunk@sai
+/plugin install go-code-review@sai
+/plugin install humanize@sai
+/plugin install kubecon-cfp@sai
+/plugin install promptgen@sai
+/plugin install review-claude-md@sai
+/plugin install staff-code-review@sai
+/plugin install staff-resume@sai
+/plugin install test-writer@sai
 ```
 
 Each plugin is independent - install only what you need.
@@ -89,7 +89,11 @@ claude --plugin-dir /path/to/sai/claude/staff-code-review
 claude --plugin-dir /path/to/sai/claude/staff-resume
 claude --plugin-dir /path/to/sai/claude/test-writer
 
-copilot plugin install /path/to/sai/plugins/council
+# Copilot CLI can load the same self-contained plugin directories directly.
+copilot --plugin-dir /path/to/sai/claude/staff-code-review
+
+# Council also has a dedicated multi-surface bundle.
+copilot --plugin-dir /path/to/sai/plugins/council
 ```
 
 ## Plugins

--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ Codex skills:
 
 Add the SAI marketplace, then install individual plugins:
 
+These examples use interactive `/plugin ...` commands, which work in both
+Copilot CLI and Claude Code sessions.
+The equivalent non-interactive forms are `copilot plugin ...` and
+`claude plugin ...`.
+
 ```bash
 # Add the SAI marketplace
 /plugin marketplace add git@github.com:smykla-skalski/sai.git

--- a/claude/kubecon-cfp/README.md
+++ b/claude/kubecon-cfp/README.md
@@ -25,7 +25,7 @@ Guides through the full CFP workflow: topic assessment against acceptance data, 
 ## Installation
 
 ```bash
-/plugin install sai/kubecon-cfp
+/plugin install kubecon-cfp@sai
 ```
 
 Or for local development:


### PR DESCRIPTION
## Summary
- correct the Copilot marketplace examples to use `plugin@marketplace` syntax
- clarify that the self-contained Copilot plugin packages live under `claude/*`, while `plugins/*` is reserved for special multi-surface bundles such as `plugins/council/`
- update the local-development guidance and the `kubecon-cfp` install example to use the validated Copilot paths

## Validation
- `copilot plugin install staff-code-review@sai`
- `copilot --plugin-dir /path/to/sai/claude/staff-code-review -p "/skills info staff-code-review" -s --allow-all`
