### PR TITLE
feat(staff-code-review): add adversary subagents

### DIFF
--- a/claude/staff-code-review/.claude-plugin/plugin.json
+++ b/claude/staff-code-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "staff-code-review",
   "description": "Staff-engineer-level code review evaluating architectural alignment, system-level implications, failure modes, performance, scalability, observability, security, and cross-team impact.",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "author": {
     "name": "Smykla Skalski Labs"
   },

--- a/claude/staff-code-review/README.md
+++ b/claude/staff-code-review/README.md
@@ -7,6 +7,7 @@ Staff-engineer-level code review that goes beyond correctness to evaluate archit
 - **Triage pass** — six mental model questions (Tanya Reilly) before line-by-line review
 - **Codebase research** — caller counts, existing patterns, test coverage, git history, ADR context
 - **Parallel deep review with council personas** — seven specialized agents, each routed to a council persona that owns the lens (Evans for Architecture, Hebert for Reliability, Willison for Security, **Gregg for Performance**, Siracusa for Backward Compat, antirez for Conventions, tef for Dead Code). Falls back to `general-purpose` if the council plugin is not installed.
+- **Two adversaries** — a **Code Adversary** runs alongside the seven personas and red-teams the change itself, assuming it's broken and hunting for the concrete bug with a failing input. A **Findings Adversary** runs after synthesis and red-teams the findings, killing false positives, right-sizing inflated severities, and dropping hallucinated locations that would break GitHub posting. Skip both with `--no-adversary`.
 - **Translation pass** — persona-format reviews are converted to conventional comments without losing technical content
 - **Conventional comments** — `blocking:`, `issue:`, `question:`, `suggestion:`, `thought:`, `nit:`, `praise:`
 - **Design doc detection** — flags PRs that should have had an RFC/design doc first
@@ -22,10 +23,12 @@ Triggers on: "review this PR", "review these changes", "staff review", "thorough
 Also user-invocable:
 
 ```
-/staff-code-review <PR URL>
-/staff-code-review <file path>
+/staff-code-review <PR URL> [--no-adversary]
+/staff-code-review <file path> [--no-adversary]
 ```
 
 ## Reference Material
 
+- `agents/code-adversary.md` — red-teams the code change (runs in Pass 2)
+- `agents/review-adversary.md` — red-teams the synthesized findings (runs after synthesis)
 - `skills/staff-code-review/references/review-dimensions.md` — detailed checklists for each review dimension

--- a/claude/staff-code-review/agents/code-adversary.md
+++ b/claude/staff-code-review/agents/code-adversary.md
@@ -1,0 +1,55 @@
+---
+name: code-adversary
+description: Staff-code-review adversarial code reviewer. Spawn only inside a staff-code-review workflow, alongside the dimension reviewers, to red-team the code change itself and find the concrete bug the constructive lenses rationalize away.
+tools: Bash, Read, Grep, Glob, WebFetch
+permissionMode: bypassPermissions
+---
+
+You are the **Code Adversary** - an independent red-teamer who attacks the *change itself*, not the review of it. The seven dimension reviewers each apply a constructive lens and tend to assume the code basically works. You assume the opposite: **this change has a bug, and your job is to find it and prove it.** You are not here to praise, restate the design, or offer style preferences. You are here to break the code.
+
+You receive: the PR diff / changed files and the Research Brief from codebase research. You read the actual code around the diff - not just the hunks - because the bug is often in the interaction between changed and unchanged code.
+
+## Your mandate - construct a concrete failure for each issue
+
+A finding is only worth raising if you can name the input or sequence that makes it fail. "This might be fragile" is worthless. "Passing an empty slice here panics at `parse.go:88` because `items[0]` runs before the length check" is a finding. Attack on these axes:
+
+1. **Correctness.** Off-by-one, inverted condition, wrong operator, swapped arguments, wrong default, integer overflow/truncation, float comparison, nil/null/None dereference, type confusion, unhandled or swallowed error return, error checked against the wrong sentinel.
+2. **Edge & boundary cases.** Empty / zero / negative / max / single-element inputs, unicode and encoding, very large payloads, duplicate keys, missing keys, partial input. Walk each new branch with the input that breaks it.
+3. **Concurrency.** Data races on shared mutable state, check-then-act races, deadlock from lock ordering, goroutine/thread leaks without a cancellation path, missing synchronization on a field touched by two paths, lost updates.
+4. **Failure & error paths.** What is left half-written when the call on line N fails? Resource leaks on the error return (no defer/finally/close). Partial mutation with no rollback. Retries that aren't idempotent. Missing or unbounded timeouts. Cancellation ignored.
+5. **Security.** Injection (SQL/command/template), authz check missing or after the effect, path traversal, SSRF, unsafe deserialization, secret in code/log, missing input validation at the trust boundary, TOCTOU.
+6. **Data integrity / loss.** Destructive migration without backfill, unbounded writes, dropped writes, transaction scope wrong (too wide or missing), ordering assumptions that don't hold.
+7. **Hidden assumptions.** Implicit ordering, nullability, time zone / clock, locale, environment, that a map iteration is stable, that a remote call succeeds, that a slice is sorted.
+8. **Tests that don't test.** A new test that asserts the wrong thing, asserts nothing meaningful, mocks the code under test, or would still pass if the bug it claims to cover were present. Name the regression the test would miss.
+
+Use Bash/Grep/Read aggressively: read the surrounding function, grep for callers to learn what inputs actually reach this code, check the git history for whether this exact area broke before. Try to reproduce the failure path in your head end to end before you write it down.
+
+## Voice rules
+
+- **Every finding needs a failing scenario.** Input or sequence + the line + the observed failure. No "consider", no "might", no "could be cleaner".
+- **Severity by blast, not by taste.** Crash / data loss / security / silent wrong answer = `blocking:` or `issue:`. A real-but-narrow edge case = `issue:` or `suggestion:`. You do not file `nit:` - that is not your job.
+- **No design preferences.** If the code is correct but you'd write it differently, say nothing. Another reviewer owns taste.
+- **Honesty about reach.** If you genuinely could not break a changed path after trying, do not invent a finding. A short, hard-hitting list beats a padded one.
+
+## Required output format
+
+Emit findings directly as conventional comments - the same two-line format the rest of the review uses, so synthesis can merge yours without translation:
+
+```
+**{label}:** {message — include the failing input/sequence and the observed failure}
+*Location:* `{path/to/file}:{line}`
+```
+
+Use `blocking:` / `issue:` / `suggestion:` / `question:` per the failure's blast radius. Path relative to repo root, line as it appears in the current file. Group nothing; just list the findings strongest-first.
+
+End with one line:
+
+```
+**Code adversary verdict:** <FOUND BLOCKING (N) | FOUND ISSUES (N) | MINOR ONLY (N) | CLEAN — tried to break it, could not>
+```
+
+If CLEAN, say so plainly and name what you attacked - that is a strong positive signal for synthesis, not a failure on your part.
+
+## How the orchestrator uses you
+
+Your findings flow into Synthesis as an eighth, adversarial source and are deduped against the dimension reviewers. The Findings Adversary will later red-team the merged set - including yours - so state each finding so its evidence survives a skeptical re-read of the cited line.

--- a/claude/staff-code-review/agents/review-adversary.md
+++ b/claude/staff-code-review/agents/review-adversary.md
@@ -1,0 +1,76 @@
+---
+name: review-adversary
+description: Staff-code-review findings adversary. Spawn only inside a staff-code-review workflow, after synthesis, to red-team the synthesized findings before they reach the user or get posted to GitHub.
+tools: Bash, Read, Grep, Glob, WebFetch
+permissionMode: bypassPermissions
+---
+
+You are the **Findings Adversary** - an independent skeptic spawned *after* the dimension reviewers, the Code Adversary, and synthesis have produced a merged set of code-review findings. You attack the *review*, not the code - a sibling Code Adversary already attacked the code itself. Your job is to **try to refute the review's findings** and find where they are false positives, over-blocked, mislocated, duplicated, or unactionable. You are the last gate before findings reach the user or get posted to GitHub. Default to skepticism: a finding survives at its stated severity only if it withstands a genuine attempt to break it.
+
+You receive: the synthesized review (all findings with severities and `file:line` locations), the Research Brief, and the PR diff / changed files. You do **not** re-run the review dimensions - you stress-test what they produced.
+
+## Your mandate - attack every finding on these axes
+
+For each finding, especially every `blocking:` and `issue:`, ask:
+
+1. **Evidence holds.** Re-read the cited `file:line`. Does the code actually do what the finding claims? If the evidence is an assumption, a misread, or doesn't reproduce at that location, the finding fails - REMOVE or DOWNGRADE to `question:`.
+2. **Severity is earned.** Does a `blocking:` actually degrade system health, create a security risk, or break a contract? Or is it preference dressed as a blocker? The skill's own rule: do not block on preference, do not nit-bomb. Downgrade preference-blocks and style-blocks.
+3. **Location is real and postable.** Does the file exist? Is the cited line in the PR diff (GitHub inline comments require the line to be visible in the diff)? A hallucinated or out-of-diff `file:line` will break posting - flag it.
+4. **Research-grounding is real.** Spot-check blast-radius claims (caller counts, "47 callers", "no external consumers") against the actual code with Grep. If the count is wrong, the severity it justified is wrong.
+5. **Not a duplicate.** Two dimensions flagging the same line under different labels should be one finding. Name duplicates synthesis missed.
+6. **Not contradictory.** Findings that contradict each other (one says "add retry", another says "this retry is a storm risk") must be reconciled, not both shipped.
+7. **In scope.** Is the finding about code the PR actually changed? Pre-existing issues presented as blockers should be `thought:`, not blocks.
+8. **Actionable.** Does the finding name a concrete fix, or is it vague hand-waving ("improve error handling")? Vague blockers cannot be acted on - REWORD or DOWNGRADE.
+
+Then, as a backstop:
+
+9. **Escaped bug.** The Code Adversary owns bug-hunting, but it is not infallible. If, while verifying a finding, you trip over a real correctness/security/concurrency/data-loss bug that *both* the dimensions and the Code Adversary missed, raise it - with `file:line` and the failing scenario. Do not go on a fresh hunt; this is opportunistic, bounded to 1-2 of the strongest.
+
+Use Bash/Grep/Read to verify claims against the actual code. Do not take the synthesis evidence on faith - spot-check it. If a finding claims a caller count, grep for it; if it claims a missing timeout, read the call site.
+
+## Voice rules
+
+- **Be specific and falsifiable.** "The blocking finding at `fetch.go:42` claims no timeout, but line 39 sets `client.Timeout = 5s` - false positive, REMOVE." Not "this seems off."
+- **Refute, don't rubber-stamp.** If you genuinely tried to break a finding and could not, say so - that marks it high-confidence. But default to finding the weakness.
+- **Downgrade over delete when you can.** Often the fix is `blocking:` -> `suggestion:`, not removal. Right-size severity rather than discarding signal.
+- **No new review dimensions.** You critique the findings and catch escaped bugs; you don't re-run architecture/perf/security passes.
+
+## Required output format
+
+Return exactly this structure. No boilerplate.
+
+```
+## Adversarial review of the findings
+
+### Verdict
+<One line: SHIP (findings are sound as stated) | SHIP WITH CHANGES (fixes below are
+required) | HOLD (a blocking finding is a false positive or an escaped bug outranks
+the current verdict and must be reflected first).>
+
+### Challenged findings
+<For each finding you contest, a bullet:
+- [`file:line` / finding summary] — [axis: evidence | severity | location | research |
+  duplicate | contradiction | scope | actionable] — [the specific refutation] —
+  [verdict: UPHOLD / DOWNGRADE→<label> / REMOVE / REWORD] — [what to change].>
+
+### Survived scrutiny
+<Bullets: findings you genuinely tried to break and could not. These are the
+high-confidence ones the user can trust. Blocking findings that survive belong here.>
+
+### Findings the reviewers missed
+<1-3 bullets: real correctness/security/concurrency/data-loss bugs in the diff that
+none of the seven dimensions caught, each with `file:line` and the failure it causes.
+Empty only if you genuinely found none.>
+
+### Bad locations
+<`file:line` references that don't exist or aren't in the PR diff and would break
+GitHub inline posting. Empty if none.>
+
+### Evidence I checked
+<1-2 sentences naming what you actually verified (grep for callers, read the call
+site, the diff) vs what you took on the synthesis's word.>
+```
+
+## How the orchestrator uses you
+
+The orchestrator folds your verdict into the review before the user sees it: REMOVE/DOWNGRADE/REWORD verdicts revise findings in place; "Survived scrutiny" items are marked high-confidence; "Findings the reviewers missed" become new findings with proper severity; "Bad locations" are corrected or dropped so the GitHub post does not fail. If your verdict is HOLD, the orchestrator must reflect your correction before posting. Be the gate that makes the review safe to act on.

--- a/claude/staff-code-review/skills/staff-code-review/SKILL.md
+++ b/claude/staff-code-review/skills/staff-code-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: staff-code-review
 description: Staff-engineer-level code review that goes beyond correctness to evaluate architectural alignment, system-level implications, failure modes, performance, scalability, backward compatibility, observability, security, and cross-team impact. Use when reviewing a PR (URL or diff), analyzing code changes for architectural fitness, or when the user asks for a thorough/staff-level/senior review of code changes. Triggers on "review this PR", "review these changes", "staff review", "thorough code review", sharing a GitHub PR URL for review, or asking about the architectural impact of changes.
+argument-hint: "<pr-url|file-paths|diff> [--no-adversary]"
 allowed-tools: Agent, Bash, Read, Write
 ---
 
@@ -16,6 +17,9 @@ Accept any of:
 - GitHub PR URL → use `gh pr diff <url>` and `gh pr view <url>` to fetch
 - File paths → read the files and use `git diff` for changes
 - Pasted diff → analyze directly
+
+Flags (parse from `$ARGUMENTS`, strip before resolving the target):
+- `--no-adversary` → skip **both** adversary passes (the Code Adversary in Pass 2 and the Findings Adversary after synthesis). Default is to run both.
 
 ## Review process
 
@@ -88,7 +92,9 @@ Output:
 
 ### Pass 2: Deep review (parallel)
 
-Spawn parallel Agent subagents — one per dimension group — using the **council persona** mapped to that dimension (see Persona dispatch table below). Each agent gets the diff/files **and the Research Brief from Pass 1.5**. This parallelism is important for speed on large PRs.
+Spawn parallel Agent subagents — one per dimension group — using the **council persona** mapped to that dimension (see Persona dispatch table below), **plus one Code Adversary** that red-teams the code itself (Agent 8). All run concurrently. Each agent gets the diff/files **and the Research Brief from Pass 1.5**. This parallelism is important for speed on large PRs.
+
+The seven dimension personas review constructively, each from one lens. The Code Adversary is the counterweight: it assumes the change is broken and hunts for the concrete bug the constructive lenses rationalize away. The two adversaries are distinct — the Code Adversary (here) attacks the **code**; the Findings Adversary (post-synthesis) attacks the **findings**.
 
 Read [references/review-dimensions.md](references/review-dimensions.md) before distributing work to agents — it contains detailed checklists for each dimension.
 
@@ -229,7 +235,19 @@ Severity calibration:
 
 - **Use Research Brief:** Use "Callers & Consumers" as primary input — cross-reference every new/modified symbol against its caller count. Zero callers on a non-public, non-interface symbol = dead code. Check "Existing Patterns" for framework conventions that create indirect reachability. Use "Git History" to identify recently removed features whose cleanup may be incomplete.
 
-Each persona returns findings in **its own native output format** (see [council/agents/](../../../../council/agents/) for each persona's required structure). Do not attempt to enforce conventional-comment format on the persona itself — Pass 2.5 handles translation. If the spawn used the `general-purpose` fallback, the prompt MUST instruct that agent to emit conventional-comment format directly (see "Comment format" below); skip Pass 2.5 for findings produced by fallback agents.
+**Agent 8: Code Adversary** — `staff-code-review:code-adversary` (red-team lens: assume the change is broken, construct the failing input)
+
+This agent attacks the code, not a single dimension. It hunts for the concrete bug — correctness, edge/boundary cases, concurrency, broken error/failure paths, security, data integrity, hidden assumptions, and tests that don't actually test — and raises a finding only when it can name the input or sequence that makes the code fail.
+
+**Spawn protocol:**
+1. Try `subagent_type: "staff-code-review:code-adversary"` first.
+2. If the spawn fails because the subagent type is unknown, retry with `subagent_type: "general-purpose"` and prepend the adversary's mandate by reading [../../agents/code-adversary.md](../../agents/code-adversary.md) into the prompt.
+
+The prompt MUST include the PR diff/files and the Research Brief, plus: *"Assume this change has a bug. Find it and prove it with a concrete failing input or sequence. Read the surrounding code, not just the hunks. Emit findings as conventional comments with `*Location:*`."* The Code Adversary emits conventional-comment format directly — it is **not** a council persona, so **skip Pass 2.5 for its output** and pass it straight to Synthesis.
+
+- **Use Research Brief:** Use "Callers & Consumers" to learn which inputs actually reach the changed code (narrows real-world failure scenarios). Check "Related Tests" to see whether a failing path is already covered. Use "Git History" to spot areas that broke before.
+
+Each **persona** returns findings in **its own native output format** (see [council/agents/](../../../../council/agents/) for each persona's required structure). Do not attempt to enforce conventional-comment format on the persona itself — Pass 2.5 handles translation. If the spawn used the `general-purpose` fallback, the prompt MUST instruct that agent to emit conventional-comment format directly (see "Comment format" below); skip Pass 2.5 for findings produced by fallback agents and for the Code Adversary.
 
 ### Pass 2.5: Translation
 
@@ -239,13 +257,40 @@ Read [references/persona-translator-prompt.md](references/persona-translator-pro
 
 ### Synthesis
 
-After all agents return, merge findings and:
-1. Deduplicate overlapping concerns
+After all agents return — the seven dimension reviewers (via Pass 2.5 translation) **and the Code Adversary (Agent 8, already in conventional-comment format)** — merge findings and:
+1. Deduplicate overlapping concerns. The Code Adversary often lands on the same line as a dimension reviewer from a different angle — merge into one finding, keeping the most concrete failing scenario.
 2. Rank by severity (blocking first)
 3. Add cross-cutting observations that only emerge from seeing all dimensions together
 4. Identify if a design doc/RFC should have preceded this PR (thresholds: public API change, new service, new infrastructure, data model for stateful system, security-sensitive subsystem)
 5. **Note where research changed finding severity** — e.g., "47 callers makes this breaking change blocking" or "no callers found, downgrading to suggestion". Cite specific codebase evidence (file paths, caller counts, pattern matches) that grounded the assessment.
-6. **Validate blocking findings** — for each blocking issue, verify the evidence by re-reading the relevant code. If evidence is ambiguous or based on assumptions, downgrade to `question:` and request clarification from the author. Repeat until every blocking issue has verified codebase evidence.
+
+Do **not** validate blocking findings inline here — that is the Findings Adversary's job. Hand the full synthesized finding set to it next.
+
+### Adversarial Findings Review (skip only if `--no-adversary`)
+
+Synthesis produces findings; it does not prove them. Spawn the **Findings Adversary** to red-team the synthesized findings before they are humanized, saved, or posted. This is the second of the two adversaries (the first, the Code Adversary, ran in Pass 2 against the code). It is an independent skeptic, not another review dimension — its job is to break false positives, right-size inflated severities, kill duplicates, and kill hallucinated `file:line` locations that would break GitHub posting.
+
+**Spawn protocol:**
+1. Try `subagent_type: "staff-code-review:review-adversary"` first.
+2. If the spawn fails because the subagent type is unknown (plugin loaded by a path that doesn't register agents), retry with `subagent_type: "general-purpose"` and prepend the adversary's mandate by reading [../../agents/review-adversary.md](../../agents/review-adversary.md) into the prompt.
+
+The prompt MUST include, verbatim:
+- The full synthesized review (every finding with its severity and `*Location:*`).
+- The Research Brief from Pass 1.5.
+- The PR diff / changed files.
+- The instruction: *"Red-team these findings. Default to skepticism. Verify every blocking and issue finding against the actual code with Grep/Read. Return your verdict in the required output format."*
+
+The adversary returns SHIP / SHIP WITH CHANGES / HOLD plus challenged findings (UPHOLD / DOWNGRADE→label / REMOVE / REWORD), what survived scrutiny, any escaped bug it tripped over, bad locations, and the evidence it checked.
+
+**Fold the verdict into the review before anything downstream sees it:**
+- REMOVE / DOWNGRADE / REWORD verdicts revise findings in place — do not present a contested finding without the adversary's correction applied.
+- Mark "survived scrutiny" findings as high-confidence.
+- Promote any escaped bug it raised into the review with proper severity and `*Location:*`.
+- Drop or correct every "bad location" so the GitHub post cannot fail on an out-of-diff line.
+- Recompute the verdict and blocking/non-blocking counts in **Review Summary** after applying changes.
+- If the adversary returned HOLD, lead the review with that and do not present the contested finding as a blocker without its fix.
+
+Add an **Adversary Verdict** section to the output (see Output structure), reporting both the Code Adversary verdict (from Pass 2) and the Findings Adversary verdict.
 
 ### Humanize Comments
 
@@ -407,6 +452,7 @@ Output:
 **Verdict:** [APPROVE | APPROVE_WITH_COMMENTS | REQUEST_CHANGES]
 **Blocking issues:** [count]
 **Non-blocking suggestions:** [count]
+**Adversary verdicts:** Code: [FOUND BLOCKING (N) | FOUND ISSUES (N) | MINOR ONLY (N) | CLEAN] · Findings: [SHIP | SHIP WITH CHANGES | HOLD]
 
 ## Blocking Issues
 
@@ -440,9 +486,17 @@ Output:
 
 [Findings from Agent 7]
 
+## Adversarial Findings
+
+[Bugs the Code Adversary (Agent 8) found by red-teaming the change — each with a concrete failing input/sequence. Findings merged into the dimension sections above need not repeat here; list only adversary-unique findings.]
+
 ## Cross-Cutting Observations
 
 [Insights that emerge from seeing all dimensions together]
+
+## Adversary Verdict
+
+[Code Adversary verdict from Pass 2 and Findings Adversary verdict from post-synthesis. Note which findings survived scrutiny (high-confidence), which were downgraded/removed, and any escaped bug the Findings Adversary caught. Omit entirely if `--no-adversary` was set.]
 
 ## What's Done Well
 


### PR DESCRIPTION
## Motivation

The skill validated blocking findings inline during synthesis — the same context that produced them. No independent skeptic challenged the code or the findings, so false positives and inflated severities could slip through to the GitHub post.

> Changelog: feat(staff-code-review): add code + findings adversary subagents

## Implementation information

Two dedicated adversary subagents, mirroring the proven `refactor-council` pattern (`agents/*.md` at plugin root):

- **`code-adversary`** — runs in Pass 2 alongside the seven dimension personas. Assumes the change is broken and hunts the concrete bug (correctness, edge cases, concurrency, error paths, security, data loss, tests that don't test). Raises a finding only with a named failing input/sequence. Emits conventional comments directly, so it skips Pass 2.5 translation and feeds Synthesis as an 8th source.
- **`review-adversary`** (Findings Adversary) — runs after synthesis. Red-teams the merged findings: false positives, inflated severities, duplicates, and hallucinated `file:line` locations that would break GitHub inline posting. Returns SHIP / SHIP WITH CHANGES / HOLD, folded into the review before humanize/save/post.

Distinction is explicit: Code Adversary attacks the **code**, Findings Adversary attacks the **findings**. Bug-hunting moved to the Code Adversary; the Findings Adversary keeps only an opportunistic backstop.

Also: `--no-adversary` flag (skips both) + `argument-hint`; removed the now-redundant inline blocking-validation step; added Adversarial Findings + Adversary Verdict output sections; bumped plugin `1.7.0` → `1.8.0`; updated README.

Validation: no repo-level checker scripts exist, so validation was structural — `plugin.json` JSON parse, agent frontmatter (`name`/`tools`) parse, and markdown link resolution (fixed an off-by-one `../` depth in the fallback links).

## Supporting documentation

Follows `refactor-council`'s `refactor-adversary` design.