### PR TITLE
feat(staff-code-review): concise posted comments

### DIFF
--- a/claude/staff-code-review/.claude-plugin/plugin.json
+++ b/claude/staff-code-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "staff-code-review",
   "description": "Staff-engineer-level code review evaluating architectural alignment, system-level implications, failure modes, performance, scalability, observability, security, and cross-team impact.",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "author": {
     "name": "Smykla Skalski Labs"
   },

--- a/claude/staff-code-review/skills/staff-code-review/SKILL.md
+++ b/claude/staff-code-review/skills/staff-code-review/SKILL.md
@@ -243,11 +243,11 @@ This agent attacks the code, not a single dimension. It hunts for the concrete b
 1. Try `subagent_type: "staff-code-review:code-adversary"` first.
 2. If the spawn fails because the subagent type is unknown, retry with `subagent_type: "general-purpose"` and prepend the adversary's mandate by reading [../../agents/code-adversary.md](../../agents/code-adversary.md) into the prompt.
 
-The prompt MUST include the PR diff/files and the Research Brief, plus: *"Assume this change has a bug. Find it and prove it with a concrete failing input or sequence. Read the surrounding code, not just the hunks. Emit findings as conventional comments with `*Location:*`."* The Code Adversary emits conventional-comment format directly — it is **not** a council persona, so **skip Pass 2.5 for its output** and pass it straight to Synthesis.
+The prompt MUST include the PR diff/files and the Research Brief, plus: *"Assume this change has a bug. Find it and prove it with a concrete failing input or sequence. Read the surrounding code, not just the hunks. Emit findings as conventional comments with `*Location:*`. Keep each message concise and easy to understand — one to two sentences, ≤280 characters, the failing input and its impact first then the fix; it posts to the PR verbatim."* The Code Adversary emits conventional-comment format directly — it is **not** a council persona, so **skip Pass 2.5 for its output** and pass it straight to Synthesis.
 
 - **Use Research Brief:** Use "Callers & Consumers" to learn which inputs actually reach the changed code (narrows real-world failure scenarios). Check "Related Tests" to see whether a failing path is already covered. Use "Git History" to spot areas that broke before.
 
-Each **persona** returns findings in **its own native output format** (see [council/agents/](../../../../council/agents/) for each persona's required structure). Do not attempt to enforce conventional-comment format on the persona itself — Pass 2.5 handles translation. If the spawn used the `general-purpose` fallback, the prompt MUST instruct that agent to emit conventional-comment format directly (see "Comment format" below); skip Pass 2.5 for findings produced by fallback agents and for the Code Adversary.
+Each **persona** returns findings in **its own native output format** (see [council/agents/](../../../../council/agents/) for each persona's required structure). Do not attempt to enforce conventional-comment format on the persona itself — Pass 2.5 handles translation. If the spawn used the `general-purpose` fallback, the prompt MUST instruct that agent to emit conventional-comment format directly, following the "Message style" rules in "Comment format" below (concise, easy to understand, one to two sentences); skip Pass 2.5 for findings produced by fallback agents and for the Code Adversary.
 
 ### Pass 2.5: Translation
 
@@ -319,7 +319,7 @@ RULES:
    - Markdown headings (##, ###)
    - The Review Summary section (verdict, counts)
    - Code blocks and inline code
-5. Keep messages concise. Staff engineers write tight prose.
+5. Make every `**{label}:**` inline comment concise and easy to understand — these post to the PR verbatim. Each: one to two sentences, ≤280 characters, problem-and-impact first then the concrete fix, plain language, no persona voice or preamble. Tighten any that ramble or bury the point. (Narrative sections outside comment blocks: remove AI patterns but do not over-compress.)
 6. Preserve all technical details, file paths, function names, and codebase evidence.
 7. Do NOT add information that was not in the original.
 8. Return the complete review markdown with humanized prose — same structure, better writing.
@@ -356,6 +356,8 @@ Create a PENDING (draft) review on the PR with inline comments. The review is in
    COMMENTS_JSON=$(python3 "${CLAUDE_SKILL_DIR}/scripts/parse_review_comments.py" "$REVIEW_FILE")
    ```
    The script extracts comments with `*Location:*` annotations and filters to: all blockers, all issues, up to 5 suggestions, and up to 3 praises. Questions, thoughts, and nits are excluded from inline comments.
+
+   Each extracted `body` posts to the PR verbatim. Confirm every one meets the "Message style" rules in "Comment format" — concise, easy to understand, one to two sentences, problem-and-impact first then the fix. If humanize left any comment verbose or unclear, tighten it in the saved review file and re-run the extraction before continuing, so the saved record and the posted comment stay in sync.
 
 3. Write a concise top-level review body (2-4 sentences max). Do NOT mention the tool, "staff code review", or that this was AI-generated. Write it as a human reviewer would:
    - Lead with the verdict (approve / request changes) and why in one sentence
@@ -405,6 +407,17 @@ Rules:
 - Line number must reference the exact line in the current file (not the diff)
 - Every file-specific comment MUST have a `*Location:*` line — comments without location cannot be posted as inline GitHub review comments
 - General observations (cross-cutting, overall praise) that don't map to a specific line may omit `*Location:*` — these go in the review body instead
+
+**Message style — posted comments must be concise and easy to understand.** The author skims them inline on the PR, so each one posts verbatim and must stand on its own:
+- Lead with the problem and its impact in the first sentence; end with the concrete fix.
+- One to two sentences, ≤ 280 characters. If it needs more, the finding is too broad — split it.
+- Plain, direct language. Strip persona voice, preamble, hedging, and restating the code.
+- Keep the technical specifics that make it actionable (file, line, symbol, caller count); drop the lecture.
+
+<example>
+Verbose: "I want to flag that, having looked at this carefully, the outbound HTTP client here appears to be constructed without any timeout configured, which in my experience tends to be the kind of thing that can cause real problems, because if the downstream service becomes unavailable the call may block indefinitely and that pressure can cascade across the system."
+Concise: "No timeout on this HTTP client — an unavailable downstream blocks indefinitely and cascades. Set an explicit request timeout."
+</example>
 
 <example>
 Input: Finding a missing timeout on an HTTP call in `pkg/client/fetch.go:42`.

--- a/claude/staff-code-review/skills/staff-code-review/references/persona-translator-prompt.md
+++ b/claude/staff-code-review/skills/staff-code-review/references/persona-translator-prompt.md
@@ -48,7 +48,9 @@ RULES:
    persona did not state.
 4. Strip persona voice scaffolding (e.g., "G'Day", "What I see", "Where I'd be
    wrong"). Keep only the actionable finding text in the message.
-5. Keep messages under 280 characters. Staff engineers write tight prose.
+5. Keep messages concise and easy to understand: one to two sentences, under 280
+   characters. Lead with the problem and its impact, then the fix; plain language
+   a busy engineer skims in seconds. This text posts to the PR verbatim.
 6. Group output by dimension heading (## Architecture & Design, ## Reliability
    & Operations, etc.) so synthesis can consume them dimension-by-dimension.
 7. Emit nothing for the persona's "Where I'd be wrong" section unless it names


### PR DESCRIPTION
## Motivation

Posted PR comments from `staff-code-review` could land verbose or unclear. Comment bodies enter via three paths — the Pass 2.5 translator (already constrained to one sentence / ≤280 chars), the Code Adversary, and `general-purpose` fallbacks (both unconstrained) — then a humanize pass that only loosely said "keep concise." So a rambling comment could reach the PR via the unconstrained paths or when humanize underperformed.

> Changelog: feat(staff-code-review): concise posted comments

## Implementation information

Defined one message-style standard and enforced it at every point a posted comment is authored or transformed:

- **Comment format** — new "Message style" rules: problem-and-impact first then the fix, one to two sentences, ≤280 chars, plain language, no persona voice. Added a verbose→concise example.
- **Humanize step** — concrete mandate scoped to `**{label}:**` blocks (they post verbatim); narrative sections stay uncompressed.
- **Code Adversary prompt** — skips the translator, so the constraint is added to its spawn instruction directly.
- **`general-purpose` fallback note** — fallback agents must follow the Message style rules.
- **Pass 2.5 translator prompt** — extended the existing length rule with "easy to understand" (problem-then-fix, plain language).
- **Post to GitHub** — guard step verifies each extracted body before submit; tighten in the saved review and re-extract so record and posted comment stay in sync.
- Bumped plugin `1.8.0` → `1.9.0`.

Validated: `plugin.json` parses, `parse_review_comments.py` still extracts correctly, and the new in-doc example does not collide with the parser regex.

## Supporting documentation

None.
