### PR TITLE
feat(generate-claude-md): add plugin

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -125,6 +125,18 @@
       "category": "Developer Tools"
     },
     {
+      "name": "generate-claude-md",
+      "source": {
+        "source": "local",
+        "path": "./plugins/generate-claude-md"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    },
+    {
       "name": "review-claude-md",
       "source": {
         "source": "local",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -140,6 +140,17 @@
       "tags": ["refactoring", "code-review", "personas", "code-smells", "technical-debt", "legacy-code"]
     },
     {
+      "name": "generate-claude-md",
+      "source": "./claude/generate-claude-md",
+      "description": "Generate a lean, high-signal CLAUDE.md from codebase analysis; built to pass review-claude-md",
+      "author": {
+        "name": "Smykla Skalski Labs"
+      },
+      "license": "MIT",
+      "category": "productivity",
+      "tags": ["claude-md", "generate", "scaffold", "best-practices"]
+    },
+    {
       "name": "review-claude-md",
       "source": "./claude/review-claude-md",
       "description": "Audit and fix CLAUDE.md files using tiered binary checklist",

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Repository layout:
 | **ai-daily-digest**     | Daily AI news digest covering technical advances, business news, and engineering impact | `claude/ai-daily-digest/`     |
 | **council**             | Run a council review when explicitly requested, through 27 sourced engineering and UX reviewer agents (antirez, tef, Muratori, Hebert, Meadows, Chin, Norman, Nielsen, Krug, Watson, Tognazzini, Tufte, etc.), and synthesize convergence, disagreement, and concrete next moves | `claude/council/`             |
 | **service-mesh-debug**  | Diagnose and fix flaky e2e tests and connectivity issues in service mesh environments (Kuma, Istio, Linkerd, Consul) | `claude/service-mesh-debug/`  |
+| **generate-claude-md**  | Generate a lean, high-signal CLAUDE.md from codebase analysis (built to pass review-claude-md) | `claude/generate-claude-md/`  |
 | **gh-review-comments**  | List, reply to, resolve, and create GitHub PR review comment threads                    | `claude/gh-review-comments/`  |
 | **git-clean-gone**      | Clean up local branches with deleted remote tracking and their worktrees               | `claude/git-clean-gone/`      |
 | **git-stage-hunk**      | Non-interactive hunk staging for selective git add without TTY                          | `claude/git-stage-hunk/`      |
@@ -59,6 +60,7 @@ The equivalent non-interactive forms are `copilot plugin ...` and
 /plugin install service-mesh-debug@sai
 
 # (Codex marketplace also provides /plugin install council@sai for Codex sessions)
+/plugin install generate-claude-md@sai
 /plugin install gh-review-comments@sai
 /plugin install git-clean-gone@sai
 /plugin install git-stage-hunk@sai
@@ -85,6 +87,7 @@ git clone git@github.com:smykla-skalski/sai.git
 claude --plugin-dir /path/to/sai/claude/ai-daily-digest
 claude --plugin-dir /path/to/sai/claude/council
 claude --plugin-dir /path/to/sai/claude/service-mesh-debug
+claude --plugin-dir /path/to/sai/claude/generate-claude-md
 claude --plugin-dir /path/to/sai/claude/gh-review-comments
 claude --plugin-dir /path/to/sai/claude/git-clean-gone
 claude --plugin-dir /path/to/sai/claude/git-stage-hunk
@@ -199,6 +202,14 @@ Refactoring review through seven sourced refactoring-and-architecture persona ag
 **Usage**: `/refactor-council <path|@file|directory> [--no-scan] [--no-adversary] [--since 12.month] [--personas a,b,c]`
 
 [Full documentation ->](./claude/refactor-council/README.md)
+
+### generate-claude-md
+
+Generate a lean, high-signal CLAUDE.md from codebase analysis. The generator counterpart to `review-claude-md` — it targets the same best-practices rubric the reviewer audits against, with a bundled validator that enforces the reviewer's Critical checks, so output is built to pass that audit. Produces exact commands, an architecture map, and real gotchas while avoiding README duplication, directory trees, and generic advice. Non-destructive: never overwrites an existing CLAUDE.md without `--force`.
+
+**Usage**: `/generate-claude-md [path/to/repo] [--update] [--force] [--rules] [--dry-run]`
+
+[Full documentation ->](./claude/generate-claude-md/README.md)
 
 ### review-claude-md
 

--- a/claude/generate-claude-md/.claude-plugin/plugin.json
+++ b/claude/generate-claude-md/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "generate-claude-md",
+  "description": "Generate a lean, high-signal CLAUDE.md from codebase analysis. Grounded in Anthropic best practices and empirical studies; built to pass review-claude-md's critical checks.",
+  "version": "0.1.0",
+  "author": {
+    "name": "Smykla Skalski Labs"
+  },
+  "repository": "https://github.com/smykla-skalski/sai",
+  "license": "MIT",
+  "keywords": ["claude-md", "generate", "scaffold", "init", "best-practices", "configuration", "codebase-analysis"]
+}

--- a/claude/generate-claude-md/README.md
+++ b/claude/generate-claude-md/README.md
@@ -1,0 +1,66 @@
+# Generate CLAUDE.md
+
+Generate a lean, high-signal CLAUDE.md for a repository from codebase analysis.
+
+The generator counterpart to [`review-claude-md`](../review-claude-md/): it targets
+the same best-practices rubric the reviewer audits against. A bundled validator
+enforces review-claude-md's Critical checks (commands present, under 150 lines, no
+README duplication, no generic advice) plus bullets and pointer style, so a
+generated file is built to pass that audit; the workflow applies the remaining
+quality (architecture relationships, domain mapping, real gotchas). It produces
+short, project-specific files and deliberately avoids what naive `/init` output
+tends to include: README duplication, directory trees, and generic advice Claude
+already knows.
+
+## Installation
+
+### Quick install
+
+```bash
+claude plugin marketplace add smykla-skalski/sai
+claude plugin install generate-claude-md@smykla-skalski-sai
+```
+
+### Manual
+
+```bash
+claude --plugin-dir /path/to/sai/claude/generate-claude-md
+```
+
+## Usage
+
+```
+/generate-claude-md [path/to/repo] [--output PATH] [--update] [--force] [--rules] [--dry-run]
+```
+
+| Flag         | Default | Purpose                                                        |
+|:-------------|:--------|:---------------------------------------------------------------|
+| (positional) | cwd     | Repo root to analyze                                           |
+| `--output`   | CLAUDE.md | Write to a specific path                                     |
+| `--update`   | off     | Merge into an existing file, preserving custom sections        |
+| `--force`    | off     | Overwrite an existing CLAUDE.md (explicit, destructive opt-in) |
+| `--rules`    | off     | Split topic detail into `.claude/rules/*.md`                   |
+| `--dry-run`  | off     | Print the result without writing                               |
+
+## Write safety
+
+Never overwrites silently. If `CLAUDE.md` already exists and neither `--update`
+nor `--force` is passed, the skill writes `CLAUDE.generated.md` next to it and
+tells you to diff and choose — so an existing file is never lost.
+
+## How it works
+
+1. Scans manifests, task runners, CI, and lint/test config (read-only subagent)
+2. Verifies build/test/lint commands are real before listing them
+3. Synthesizes only project-specific, non-obvious content, applying the deletion
+   test to every line
+4. Splits into `.claude/rules/` when over the length budget
+5. Validates the result with a bundled checker (line count, README de-duplication,
+   no directory tree, no generic advice, bullet ratio, commands present) and
+   iterates until it passes
+
+After generating, audit anytime with `/review-claude-md`.
+
+## License
+
+MIT - See [../../LICENSE](../../LICENSE)

--- a/claude/generate-claude-md/skills/generate-claude-md/SKILL.md
+++ b/claude/generate-claude-md/skills/generate-claude-md/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: generate-claude-md
+description: Generate a lean, high-signal CLAUDE.md for a repository from codebase analysis. Grounded in Anthropic best practices and empirical studies; built to pass review-claude-md (a bundled validator enforces the same critical checks). Use when the user asks to "generate CLAUDE.md", "create a CLAUDE.md", "write a CLAUDE.md", "init CLAUDE.md", "scaffold CLAUDE.md", or "bootstrap CLAUDE.md" for a project.
+argument-hint: "[path/to/repo] [--output PATH] [--update] [--force] [--rules] [--dry-run]"
+allowed-tools: Bash, Edit, Glob, Grep, Read, Task, Write
+user-invocable: true
+context: fork
+agent: general-purpose
+---
+
+<!-- justify: writes a new CLAUDE.md; non-destructive by default, never overwrites an existing file without --force -->
+
+# Generate CLAUDE.md
+
+Build a project-specific CLAUDE.md that earns every line: exact commands, an
+architecture map, real gotchas, and enforced boundaries — and nothing Claude
+already knows. The goal is the inverse of naive `/init` output: short, specific,
+and free of README duplication, directory trees, and generic filler.
+
+This skill is the generator counterpart to the `review-claude-md` plugin. It
+targets the same rubric the reviewer audits against. The bundled validator
+(Phase 7) deterministically gates the mechanical checks — commands present,
+length, no README duplication, no generic advice, no directory tree, bullets —
+which are all of the reviewer's Critical checks, so a passing file cannot earn a
+review FAIL verdict. The remaining quality (architecture as relationships, domain
+mapping, real gotchas, style deltas) is your job during synthesis. Read
+[references/principles.md](references/principles.md) in full before synthesizing —
+it is the source of truth for every rule below.
+
+## Arguments
+
+Parse from `$ARGUMENTS`:
+
+- First positional arg: repo root (default: current working directory)
+- `--output PATH` — write to PATH instead of `<repo>/CLAUDE.md`
+- `--update` — merge into an existing CLAUDE.md, preserving sections this skill
+  does not manage; regenerate the rest
+- `--force` — overwrite an existing CLAUDE.md (explicit, destructive opt-in)
+- `--rules` — split topic detail into `.claude/rules/*.md` even under the budget
+- `--dry-run` — return the generated content without writing any file
+
+## Write safety (read first)
+
+Never silently overwrite. Decide the write target like this:
+
+1. Resolve target: `--output PATH`, else `<repo>/CLAUDE.md`.
+2. Target does **not** exist → write it directly.
+3. Target exists and `--force` → overwrite it (the flag is the explicit approval).
+4. Target exists and `--update` → merge (see Phase 6), then write the target.
+5. Target exists, no flag → **do not touch it.** Write to
+   `<dir>/CLAUDE.generated.md` and report that the user should diff it against the
+   current file, then re-run with `--update` or `--force`.
+6. `--dry-run` → write nothing; return the content in the report.
+
+## Workflow
+
+### Phase 1: Setup
+
+1. Resolve repo root and the write target per Write safety above.
+2. Detect existing context: `CLAUDE.md`, `.claude/CLAUDE.md`, `.claude/rules/*`,
+   `AGENTS.md`, `.cursorrules`. Note whether `AGENTS.md` exists (drives bridging).
+3. Confirm `README.md` presence (used to avoid duplication).
+
+### Phase 2: Scan the codebase
+
+Spawn one `Explore` agent. Pass it the repo root and the full contents of
+[references/scan-spec.md](references/scan-spec.md) as its instructions. It reads
+manifests, task runners, CI, lint/test config, entry points, and git history, and
+returns the compact structured summary that file specifies. Do not re-read what
+the agent already summarized.
+
+### Phase 3: Verify commands
+
+For each build/test/lint/run command in the summary, confirm it is real with a
+non-destructive probe (`--help`, `--version`, `make -n <target>`, a script entry
+in a manifest, or its presence in CI). Drop or mark `(unverified)` anything that
+cannot be confirmed. Prefer the form CI uses over the README form.
+
+### Phase 4: Synthesize
+
+Read [references/principles.md](references/principles.md) and
+[references/section-guide.md](references/section-guide.md) before writing. Then
+build the file:
+
+1. Work section by section in the priority order from the section guide. Include a
+   section only if it has real, project-specific content.
+2. Apply the deletion test to **every** line: "Would removing this cause Claude to
+   make a mistake?" If no, cut it.
+3. Use `file:line` pointers, never pasted code. Phrase rules positively ("use Y").
+   Bullets, not paragraphs. Reserve emphasis for at most a couple of lines.
+4. Do not duplicate README headings (from the summary). No directory tree. No
+   standard language conventions. No generic advice.
+5. If `AGENTS.md` exists, bridge instead of duplicating: make the first line
+   `@AGENTS.md` and add only Claude-specific content. See
+   [references/modularization.md](references/modularization.md).
+
+See [references/example.md](references/example.md) for a full worked file and a
+counter-example.
+
+### Phase 5: Budget & modularization
+
+1. Count lines. Keep the root **under 150 lines** — this is the limit
+   `review-claude-md` enforces (its C2 check), so staying under it is what makes
+   the output pass that audit. The official ceiling is 200, but 150 is the binding
+   target here. Aim well below it.
+2. If over budget, or if `--rules` was passed, move topic detail into
+   `.claude/rules/*.md` per [references/modularization.md](references/modularization.md),
+   using `paths:` frontmatter to scope rules to globs. Keep commands, the
+   architecture map, top gotchas, and etiquette in the root, and link each rule
+   file from the root with a one-line description.
+
+### Phase 6: Write
+
+- Default / `--force`: write the synthesized content to the target.
+- `--update`: read the existing file, keep any heading this skill does not manage
+  (preserve user-authored sections verbatim), replace the managed sections with
+  the freshly synthesized ones, and write the merged result. Never drop a section
+  you did not generate.
+- Create any `.claude/rules/*.md` files from Phase 5.
+- `--dry-run`: skip all writes.
+
+### Phase 7: Validate & iterate
+
+Run the validator on the written file (or, for `--dry-run`, on a temp copy):
+
+```bash
+python3 "${CLAUDE_SKILL_DIR}/scripts/validate-claude-md.py" "<target-file>" --human
+```
+
+Parse the result. For any `[FAIL]` check, fix the file and re-run. Iterate up to
+3 rounds. The validator enforces line count, README de-duplication, no generic
+advice, no directory tree, no oversized code blocks, bullet ratio, and the presence
+of build/test/lint commands plus a pre-commit gate — mirroring the same checks
+`review-claude-md` runs (its command checks skip automatically for AGENTS.md bridge
+files). A genuinely-absent command (e.g. a project with no linter) should be
+reported honestly, not invented.
+
+### Phase 8: Report
+
+Return a summary:
+
+- Target path written (or the `.generated.md` fallback / dry-run notice)
+- Final line count and the validator verdict (PASS, or remaining advisories)
+- Sections included and any `.claude/rules/*.md` created
+- If a `.generated.md` fallback was used: the exact next step (diff, then `--update`
+  or `--force`)
+- One or two follow-ups the human should confirm (e.g. an unverified command, a
+  gotcha that needs a real `file:line`)
+
+## Error handling
+
+- **No manifests / unknown stack**: infer commands from CI and scripts; if still
+  unknown, omit the Commands section rather than guessing, and flag it in the report.
+- **Empty or trivial repo**: generate only the sections with real content (often
+  just Commands). Do not pad to look complete.
+- **Existing CLAUDE.md and no flag**: never overwrite — use the `.generated.md`
+  fallback and tell the user how to proceed.
+- **Validator keeps failing after 3 rounds**: write the best version, report the
+  remaining failing checks honestly, and suggest `/review-claude-md --fix`.
+
+## Example invocations
+
+<example>
+Generate for the current repo:
+
+```bash
+/generate-claude-md
+```
+</example>
+
+<example>
+Specific repo, preview without writing:
+
+```bash
+/generate-claude-md /path/to/repo --dry-run
+```
+</example>
+
+<example>
+Refresh an existing file, preserving custom sections:
+
+```bash
+/generate-claude-md --update
+```
+</example>
+
+<example>
+Force a lean rewrite and split topics into rules:
+
+```bash
+/generate-claude-md --force --rules
+```
+</example>

--- a/claude/generate-claude-md/skills/generate-claude-md/references/example.md
+++ b/claude/generate-claude-md/skills/generate-claude-md/references/example.md
@@ -1,0 +1,90 @@
+# Worked Example
+
+A complete, ideal CLAUDE.md for a Go payments API (~35 lines), then notes on why
+each choice was made. Use it as a shape reference, not a template to copy
+verbatim — every line is specific to its project.
+
+## The file
+
+```markdown
+# Acme Payments API
+
+## Commands
+- Build: `make build`
+- Run (local): `make run` (needs `docker compose up -d db redis` first)
+- Test (full): `go test ./...`
+- Test (focused): `go test ./internal/ledger -run TestApply`
+- Lint: `golangci-lint run` (also the pre-commit gate, via `.pre-commit-config.yaml`)
+
+## Architecture
+- `internal/http/` handlers validate + decode, then call `internal/svc/`;
+  services never import `internal/http/` (enforced by `make lint`)
+- `internal/svc/` orchestrates domain logic; `internal/ledger/` is the only
+  package that writes money rows, always inside a DB transaction
+- All Stripe webhooks enter through one handler: `internal/http/webhook.go:41`
+- Request flow: handler → service → ledger → `internal/store/` → response
+
+## Domain
+- "Intent" = a not-yet-captured charge (`internal/ledger/intent.go`); "Entry" =
+  an immutable ledger row. Never mutate an Entry — append a reversing Entry.
+
+## Testing
+- Single test: `go test ./internal/ledger -run TestApply`
+- Mock external calls at the `Gateway` interface (`internal/svc/gateway.go:12`);
+  do not hit Stripe in unit tests
+- Ledger tests need Postgres: `docker compose up -d db`, then `make migrate`
+
+## Gotchas
+- The ledger is append-only — a "correction" is a new reversing Entry, never an
+  UPDATE (`internal/ledger/apply.go:88`)
+- Webhook handlers must be idempotent on `idempotency_key`; Stripe retries
+  (`internal/http/webhook.go:41`)
+- `make migrate` must run before ledger tests or they fail on a missing table
+
+## Commits
+- Conventional commits, scope required: `fix(ledger): guard against double apply`
+- Branch from `main`; PRs need green CI + one approval
+```
+
+## Why each choice
+
+- **No tech-stack section, no directory tree.** The language is obvious from the
+  files and the README already lists dependencies. A tree would add lines and zero
+  signal.
+- **Commands first, with a focused-test command and the gate named.** This is the
+  section Claude uses every session.
+- **Architecture states boundaries and the one webhook entry point** with
+  `file:line`, instead of listing packages. The "services never import handlers"
+  rule is the kind of thing Claude would otherwise violate.
+- **Domain maps two terms to code** — the append-only ledger model is the project's
+  core invariant and not inferable from a quick read.
+- **Gotchas all have locations and failure modes.** Each one prevents a concrete
+  mistake; none is generic advice.
+- **~35 lines.** Well under the 150 limit; every line passes "would removing this
+  cause a mistake?".
+
+## Counter-example (what NOT to generate)
+
+```markdown
+# Acme Payments API
+
+Acme Payments API is a Go service for processing payments. It is built with Go
+1.22 and uses PostgreSQL, Redis, and the Stripe API.        ← README duplication
+
+## Project Structure                                         ← directory tree
+internal/
+  http/
+  svc/
+  ledger/
+  store/
+
+## Code Style
+Write clean, idiomatic Go. Handle all errors. Use gofmt.     ← generic + defaults
+
+## Testing
+Write tests for new code and make sure they pass.            ← self-evident filler
+```
+
+Every line here fails the rubric: README dup, a tree, generic advice, and
+self-evident filler. This is roughly what naive auto-generation (`/init`) tends to
+produce, and what this skill exists to avoid.

--- a/claude/generate-claude-md/skills/generate-claude-md/references/modularization.md
+++ b/claude/generate-claude-md/skills/generate-claude-md/references/modularization.md
@@ -1,0 +1,101 @@
+# Modularization, Hierarchy & Cross-Tool Bridging
+
+How to keep the root file lean when there is genuinely more to say, and how to
+fit into the CLAUDE.md hierarchy and the AGENTS.md ecosystem.
+
+## Contents
+
+- [When to split](#when-to-split)
+- [.claude/rules/ with path scoping](#clauderules-with-path-scoping)
+- [@imports vs rules](#imports-vs-rules)
+- [The load hierarchy](#the-load-hierarchy)
+- [Monorepos: nested CLAUDE.md](#monorepos-nested-claudemd)
+- [Bridging AGENTS.md](#bridging-agentsmd)
+
+---
+
+## When to split
+
+Default to a single root `CLAUDE.md`. Split only when content is genuinely
+valuable AND the root would exceed ~150 lines, or when a topic applies only to a
+subset of files. Splitting trades one always-loaded file for lazy-loaded topic
+files — useful, but each split adds indirection, so don't over-modularize a small
+project.
+
+Keep in the root: commands, the architecture map, top gotchas, repo etiquette.
+Move to a rule file: long topic detail (test infrastructure, a subsystem's
+conventions, a release runbook) that is not needed every session.
+
+## .claude/rules/ with path scoping
+
+`.claude/rules/*.md` are topic files. The key feature: **`paths:` frontmatter
+scopes a rule to globs**, so it loads only when Claude touches matching files —
+saving context the rest of the time.
+
+```markdown
+---
+paths:
+  - "src/payments/**"
+---
+- Payment intents are idempotent on `idempotency_key`; never retry without it
+- Webhook signatures verified in `src/payments/webhook.ts:18` — never bypass
+```
+
+A rule file **without** `paths:` loads at launch with the same priority as the
+root file — use that only for rules that truly apply everywhere. When you move
+content into a rule, link it from the root with a one-line description so a reader
+(and Claude) knows it exists:
+
+```markdown
+- Payments conventions: see `.claude/rules/payments.md` (loads when editing `src/payments/`)
+```
+
+## @imports vs rules
+
+`@path` imports pull another file in **at launch, in full** — they organize but do
+**not** save context (max depth 4 hops). Use imports for "always-on" shared content
+(e.g. bridging AGENTS.md); use path-scoped rules for "load only when relevant".
+To mention a path without importing it, wrap it in backticks (`` `@README` ``).
+
+## The load hierarchy
+
+Files are concatenated, broadest → most specific; later wins on conflict:
+
+1. Managed policy (org-wide, cannot be excluded by the user)
+2. User `~/.claude/CLAUDE.md` (personal, all projects)
+3. Project `./CLAUDE.md` or `./.claude/CLAUDE.md` (team-shared, git-tracked) ← **the target**
+4. `./CLAUDE.local.md` (personal, gitignored)
+5. Parent dirs load before child dirs; child dirs load on demand when Claude reads them
+
+Generate the **project** file. Do not restate anything that belongs in the user or
+managed layers (personal preferences, org policy). Put personal-only notes in
+`CLAUDE.local.md` and keep it gitignored.
+
+## Monorepos: nested CLAUDE.md
+
+For a monorepo, keep a short root CLAUDE.md with cross-cutting facts, and put a
+focused CLAUDE.md in each sub-project directory — the nested file loads on demand
+when Claude works in that subtree. Don't cram every sub-project's commands into the
+root.
+
+## Bridging AGENTS.md
+
+AGENTS.md is the cross-tool standard (read by Codex, Cursor, Aider, Copilot, Gemini
+CLI, and more). Claude Code does **not** read AGENTS.md natively. If the repo has
+(or should have) an AGENTS.md:
+
+- Put universal, tool-agnostic rules in `AGENTS.md`.
+- Make `CLAUDE.md` bridge to it: the **first line** is `@AGENTS.md`, followed by
+  Claude-specific additions (plan-mode notes, hooks, imports). Claude loads the
+  import then appends the Claude-only content.
+- If there are no Claude-specific additions at all, a symlink `CLAUDE.md → AGENTS.md`
+  works (but a Windows checkout needs the `@AGENTS.md` import form instead).
+
+```markdown
+@AGENTS.md
+
+## Claude-specific
+- Use the `git-stage-hunk` skill for partial commits
+```
+
+This keeps one source of truth and avoids duplicating shared rules across two files.

--- a/claude/generate-claude-md/skills/generate-claude-md/references/principles.md
+++ b/claude/generate-claude-md/skills/generate-claude-md/references/principles.md
@@ -1,0 +1,135 @@
+# CLAUDE.md Generation Principles
+
+The rules a generated CLAUDE.md must follow, with the evidence behind each.
+Apply every rule during synthesis. These mirror what the `review-claude-md`
+plugin audits against, so a file built to these principles passes that audit.
+
+## Contents
+
+- [The one test that governs everything](#the-one-test-that-governs-everything)
+- [What goes in (priority order)](#what-goes-in-priority-order)
+- [What stays out](#what-stays-out)
+- [How to write each line](#how-to-write-each-line)
+- [Length budget](#length-budget)
+- [Sources](#sources)
+
+---
+
+## The one test that governs everything
+
+For every candidate line, ask: **"Would removing this cause Claude to make a
+mistake?"** If no, cut it. This is the official pruning test and the single most
+important rule — bloat causes Claude to ignore the instructions that matter.
+(Anthropic Best Practices)
+
+A CLAUDE.md is **AI-operational context, not human onboarding docs**. It exists
+to encode the deltas a model cannot infer from the code: exact commands, hidden
+constraints, enforced boundaries, domain mappings. Everything else is noise.
+
+---
+
+## What goes in (priority order)
+
+Order matters — models follow early instructions more reliably than mid-file
+ones ("lost in the middle"). Put the highest-value, most-violated rules first.
+
+1. **One-line project identity** — only if not obvious from the name. Often skip.
+2. **Commands** (highest value): exact build / test / lint / run / single-test
+   invocations with real flags. These are what Claude cannot guess and what it
+   needs every session. (Builder.io, Anthropic) Empirically the most common and
+   most useful section (Build/Run ~62–77% of real files; Santos et al., Agent
+   READMEs study).
+3. **Architecture map**: how components relate and what boundaries are enforced
+   — not a directory tree. "Services never import handlers." Data flow in one
+   line. Point to the one entry point that matters with `file:line`. (HumanLayer)
+4. **Code-style deltas**: only conventions that differ from the language default,
+   and point at the config file rather than restating its rules. (Anthropic)
+5. **Testing**: framework, how to run one test, what to mock, fixtures/teardown
+   requirements. (Builder.io)
+6. **Repo etiquette**: branch/PR/commit conventions the project actually enforces.
+7. **Gotchas**: project-specific traps with `file:line` — test ordering, required
+   migrations, eventual consistency, env vars that must be set. (Arize)
+8. **Security / file boundaries**: paths never to touch, generated files, secrets
+   handling — only if real for this repo.
+
+A section earns its place only if it has real, project-specific content. Omit any
+section you would have to fill with generic filler.
+
+---
+
+## What stays out
+
+The official exclude-list (Anthropic Best Practices), plus empirically-confirmed
+anti-patterns:
+
+- **Anything Claude can read from the code.** No file-by-file descriptions.
+- **No directory tree / file enumeration** — provides no measured navigation
+  benefit and burns the attention budget. Give a map, not a listing.
+- **No README duplication.** LLM-generated files that duplicate README content
+  measurably *lower* task success (~−2%) and raise cost (~+23%). (AGENTS.md
+  efficiency study; Augment Code) Reference the README, don't restate it.
+- **No standard language conventions** Claude already knows (PEP 8, gofmt, etc.).
+- **No self-evident advice** ("write clean code", "handle errors gracefully",
+  "make sure tests pass"). Claude already knows this; it only adds noise.
+- **No embedded code snippets** that will rot — use `file:line` pointers instead.
+- **No detailed API docs, tutorials, or long prose** — link out instead.
+- **No secrets, credentials, connection strings, or vulnerability details.**
+- **No frequently-changing facts** (version numbers that churn, in-flight TODOs).
+- **No linter's job.** Don't tell Claude to format code; a Stop hook running the
+  formatter is deterministic where a CLAUDE.md line is only advisory. (HumanLayer)
+
+---
+
+## How to write each line
+
+- **Pointers over copies.** Reference `path/file.ext:line`, never paste code that
+  drifts out of date. (HumanLayer)
+- **Positive phrasing.** "Use Y" beats "don't use X" — flipping negative rules to
+  positive roughly halves violations. Reserve a negative only to name a genuinely
+  banned pattern ("Use functional components; class components are not allowed").
+- **Bullets over paragraphs.** Terse, scannable, one fact per bullet.
+- **Exact commands.** Copy-pasteable with flags, not "run the tests".
+- **Emphasis discipline.** IMPORTANT / YOU MUST raise adherence but only if rare —
+  "if everything is IMPORTANT, nothing is." Use on at most a couple of lines.
+- **No contradictions.** Conflicting rules without a priority order degrade
+  behavior sharply (resolve rates dropped ~49% → 28% in one study). If two rules
+  could conflict, state which wins.
+
+---
+
+## Length budget
+
+- **Binding target: under 150 lines** for the root file. The official ceiling is
+  200 (Anthropic Memory docs), but the `review-claude-md` audit fails any root over
+  150 (its C2 check), so 150 is the limit to build to — and staying under it is what
+  makes generated output pass that audit. Aim well below it.
+- Strong real-world root files run 50–100 lines; HumanLayer's is under 60.
+- The rationale: frontier models follow ~150–200 instructions consistently, and
+  Claude Code's own system prompt already spends ~50 of that budget. Every line
+  competes for a fixed attention budget. (HumanLayer)
+- If content genuinely exceeds the budget, **modularize** — keep the root under 150
+  and move topic detail into `.claude/rules/*.md`. See the modularization guide.
+
+---
+
+## Sources
+
+Last verified 2026-06. Re-verify quarterly or when a link fails.
+
+- Anthropic Best Practices: https://code.claude.com/docs/en/best-practices
+- Anthropic Memory: https://code.claude.com/docs/en/memory
+- Anthropic blog — Using CLAUDE.md: https://claude.com/blog/using-claude-md-files
+- Builder.io: https://www.builder.io/blog/claude-md-guide
+- HumanLayer: https://www.humanlayer.dev/blog/writing-a-good-claude-md
+- Arize (prompt-learning, +5–11% accuracy from instruction tuning):
+  https://arize.com/blog/claude-md-best-practices-learned-from-optimizing-claude-code-with-prompt-learning/
+- Santos et al. (253 files):  https://arxiv.org/html/2509.14744v1
+- Agent READMEs (2,303 files): https://arxiv.org/html/2511.12884v1
+- AGENTS.md efficiency study (124 PRs, −20% tokens with a context file):
+  https://arxiv.org/html/2601.20404v1
+- Augment Code — AGENTS.md guide: https://www.augmentcode.com/guides/how-to-build-agents-md
+
+Note on provenance: the developer-written > LLM-generated, no-directory-tree, and
+README-redundancy findings are sourced here to Santos et al., the Agent READMEs
+study, the AGENTS.md efficiency study, and Augment Code (all cited above). Use
+these primary sources when citing those findings.

--- a/claude/generate-claude-md/skills/generate-claude-md/references/scan-spec.md
+++ b/claude/generate-claude-md/skills/generate-claude-md/references/scan-spec.md
@@ -1,0 +1,65 @@
+# Codebase Scan Specification
+
+Instructions for the `Explore` agent that gathers the facts a CLAUDE.md is built
+from. The agent reads, never writes. It returns a compact structured summary —
+not file dumps. Keep the summary tight; the synthesis step turns it into a lean
+file, so raw volume here just gets discarded.
+
+## What to read
+
+- **Package / build manifests**: `package.json`, `pyproject.toml`, `go.mod`,
+  `Cargo.toml`, `pom.xml`, `build.gradle`, `Gemfile`, `composer.json`.
+- **Task runners**: `Makefile`, `Taskfile.yml`, `justfile`, `mise.toml`,
+  `package.json` scripts, `pyproject.toml` `[tool.*]` script tables.
+- **CI**: `.github/workflows/*`, `.gitlab-ci.yml`, `.circleci/config.yml` — the
+  real build/test/lint commands the project runs live here.
+- **Lint/format config**: `.eslintrc*`, `biome.json`, `.prettierrc*`, `ruff.toml`,
+  `.golangci.yml`, `rustfmt.toml`, `.editorconfig`.
+- **Test config**: `jest.config.*`, `vitest.config.*`, `pytest.ini`,
+  `pyproject.toml` `[tool.pytest]`, `go` test layout, `conftest.py`.
+- **Pre-commit / hooks**: `.pre-commit-config.yaml`, `.husky/`, `lefthook.yml`.
+- **Existing context files**: `CLAUDE.md`, `.claude/CLAUDE.md`, `.claude/rules/*`,
+  `AGENTS.md`, `.cursorrules`, `.windsurfrules` — preserve and reconcile, don't
+  discard.
+- **README.md**: read it to know what NOT to duplicate.
+- **Top-level layout + entry points**: enough to describe component relationships
+  (where handlers/services/data-access/domain logic live), not to enumerate files.
+- **`git log --oneline -20`**: infer the commit-message convention.
+
+## What to return
+
+A structured summary with exactly these fields. Use "none found" when a field is
+empty — do not invent.
+
+- **project_name** and a one-line purpose (only if not obvious from the name).
+- **commands**: build, test (full), test (single — infer the framework's syntax),
+  lint, format, run/dev, and any pre-commit gate. Give exact invocations with flags.
+- **architecture**: 3–6 bullet points on component relationships and enforced
+  boundaries, each with a `file:line` anchor where one exists. Name the one or two
+  entry points that matter (main, router, webhook handler, CLI root).
+- **style_deltas**: conventions that differ from the language default, each with
+  the config file that owns the rule. Empty if style is just formatter defaults.
+- **testing**: framework, single-test command, mock strategy, fixture/teardown or
+  integration prerequisites (Docker, env vars, live services).
+- **repo_etiquette**: commit convention (from git log), branch/PR rules (from CI
+  or CONTRIBUTING).
+- **gotcha_candidates**: non-obvious traps detectable from code — custom test
+  setup/teardown, migration ordering, env vars required at import time, generated
+  directories, eventual-consistency comments, `// HACK`/`// NOTE` markers. Each
+  with `file:line`.
+- **boundaries**: generated/vendored paths, secret handling, off-limits dirs.
+- **readme_headings**: the section headings present in README.md, so synthesis can
+  avoid duplicating them.
+- **existing_context**: contents/topics of any existing CLAUDE.md, `.claude/rules/`,
+  or AGENTS.md, and whether an AGENTS.md exists (drives cross-tool bridging).
+- **commit_convention**: the observed format (e.g. conventional commits, scope
+  required) inferred from recent history.
+
+## Rules for the agent
+
+- Verify commands exist where cheap: a command named in CI or a Makefile target is
+  trustworthy; flag anything inferred/guessed as `(unverified)`.
+- Prefer the command form CI uses over the one in the README — CI is ground truth.
+- Do not return file contents or long excerpts; return facts and `file:line` anchors.
+- If the repo is multi-language or a monorepo, note the sub-projects and where each
+  one's commands live (this drives whether to split into nested CLAUDE.md / rules).

--- a/claude/generate-claude-md/skills/generate-claude-md/references/section-guide.md
+++ b/claude/generate-claude-md/skills/generate-claude-md/references/section-guide.md
@@ -1,0 +1,201 @@
+# Section Authoring Guide
+
+For each section: what to put in, what to leave out, and a good/bad example pair.
+Build sections in this order. Include a section only when it has real,
+project-specific content — never emit an empty or filler section.
+
+## Contents
+
+- [Header / identity](#header--identity)
+- [Commands](#commands)
+- [Architecture](#architecture)
+- [Code style](#code-style)
+- [Testing](#testing)
+- [Repo etiquette](#repo-etiquette)
+- [Gotchas](#gotchas)
+- [Security / boundaries](#security--boundaries)
+
+---
+
+## Header / identity
+
+One line, only if the project's purpose is not obvious from its name. No tagline,
+no marketing, no tech-stack list (that duplicates the README and the package file).
+
+Often the best header is just `# <name>` with no description, then straight to
+Commands.
+
+---
+
+## Commands
+
+The single highest-value section. List the exact, copy-pasteable invocations
+Claude needs every session. Always include a focused/single-test command and the
+pre-commit gate.
+
+### Good
+
+```markdown
+## Commands
+- Build: `make build`
+- Test (full): `go test ./...`
+- Test (focused): `go test ./pkg/auth -run TestLogin`
+- Lint: `golangci-lint run`
+- Pre-commit gate: `make lint && go test ./...`
+```
+
+### Bad
+
+```markdown
+## Commands
+- Build the project
+- Run the tests
+- Make sure linting passes
+```
+
+No actual commands, no focused-test option, no gate. Claude cannot run these.
+
+---
+
+## Architecture
+
+Explain how components relate and what boundaries are enforced. One line per
+relationship. Point at the one or two entry points that matter with `file:line`.
+**Never a directory tree.**
+
+### Good
+
+```markdown
+## Architecture
+- `internal/http/` handlers call `internal/svc/` services; services never import
+  handlers (enforced by `make lint`)
+- All Stripe webhooks enter through one handler: `internal/svc/billing.go:34`
+- Request flow: handler → service → `internal/store/` query → response
+```
+
+### Bad
+
+```markdown
+## Architecture
+internal/
+  http/
+  svc/
+  store/
+  util/
+```
+
+A file tree with no relationships, no boundaries, no entry points. Claude learns
+nothing it could not get from `ls`.
+
+---
+
+## Code style
+
+Only conventions that **differ** from the language default. Point at the config
+file; do not restate its rules. If the project's style is just "the formatter's
+defaults", omit this section entirely.
+
+### Good
+
+```markdown
+## Style
+- DB columns are `snake_case` (differs from the JS `camelCase` elsewhere)
+- Every error response includes an `error_code` — registry in `src/errors.ts:8`
+- Import order is enforced by ESLint (`.eslintrc.js`); do not hand-order
+```
+
+### Bad
+
+```markdown
+## Style
+We use TypeScript. Add type annotations to all parameters and return values.
+Prefer `const` over `let`. Use 2-space indentation. Name variables descriptively.
+```
+
+Restates language defaults and linter-enforced rules Claude already follows.
+
+---
+
+## Testing
+
+Framework, how to run a single test, what to mock, and any fixture/teardown
+requirement that bites if missed.
+
+### Good
+
+```markdown
+## Testing
+- Framework: pytest; run one test with `pytest tests/test_auth.py::test_login`
+- Mock the network at the `httpx` transport layer — see `tests/conftest.py:20`
+- Integration tests need a live Postgres: `docker compose up -d db` first
+```
+
+### Bad
+
+```markdown
+## Testing
+Write tests for your code. Make sure all tests pass before committing. Aim for
+high coverage.
+```
+
+Generic advice with no framework, no run command, no project specifics.
+
+---
+
+## Repo etiquette
+
+Only conventions the project actually enforces. Commit format, branch naming, PR
+rules. Skip if the project has no special convention.
+
+### Good
+
+```markdown
+## Commits
+- Conventional commits, scope required: `feat(api): add login endpoint`
+- Branch from `main`; PRs need one approval and green CI
+```
+
+---
+
+## Gotchas
+
+Project-specific traps that cost time when unknown. Each must point at a `file:line`
+and describe the failure mode. This is where tribal knowledge becomes durable.
+
+### Good
+
+```markdown
+## Gotchas
+- Tests touching the `orders` table must call `resetOrderSequence()` in teardown
+  or later tests hit duplicate-key errors (`test/helpers.ts:12`)
+- The payment service is eventually consistent — check `transaction.status`
+  before assuming completion (`services/payment.ts:45`)
+- `DATABASE_URL` must be set even for unit tests; the client constructs at import
+  time (`src/db/client.ts:3`)
+```
+
+### Bad
+
+```markdown
+## Gotchas
+- Handle errors gracefully
+- Don't forget to update documentation
+- Be careful with the database
+```
+
+Generic, no locations, no failure modes. Applies to any project; helps with none.
+
+---
+
+## Security / boundaries
+
+Only if real for this repo: generated files never to edit, paths off-limits,
+secret-handling rules.
+
+### Good
+
+```markdown
+## Boundaries
+- `src/generated/` is codegen output — edit the `.proto` files, never the `.ts`
+- Never commit `.env`; secrets load from Vault at boot (`src/config/secrets.ts:10`)
+```

--- a/claude/generate-claude-md/skills/generate-claude-md/scripts/validate-claude-md.py
+++ b/claude/generate-claude-md/skills/generate-claude-md/scripts/validate-claude-md.py
@@ -1,0 +1,611 @@
+#!/usr/bin/env python3
+"""Validate a generated CLAUDE.md against the lean, high-signal rubric.
+
+Purpose:
+    Deterministic gate for the generate-claude-md skill. After synthesis, the
+    skill runs this over the candidate file and revises until every critical
+    check passes. The checks mirror the same best-practices the review-claude-md
+    plugin audits against (Anthropic docs + empirical studies) - including all of
+    its Critical checks - so a file that passes here cannot earn a review FAIL.
+
+Checks:
+    GC-file-exists      - target CLAUDE.md exists and is non-empty (gate).
+    GC-line-count       - file within the line limit (<=150, matches review C2).
+    GC-readme-dup       - leading lines not copied from README.
+    GC-generic-advice   - no advice Claude already knows ("write clean code").
+    GC-directory-tree   - no ASCII directory tree / file-by-file enumeration.
+    GC-long-code-block  - no fenced block over the snippet budget (pointers win).
+    GC-bullets-ratio    - structured as bullets, not prose paragraphs.
+    GC-build-command    - a build command is present (mirrors review has-build).
+    GC-test-command     - a test command is present (mirrors review has-test).
+    GC-lint-command     - a lint command is present (mirrors review has-lint).
+    GC-precommit        - a pre-commit gate is documented (review has-precommit).
+    GC-file-pointers    - uses file or file:line pointers (advisory).
+    GC-emphasis         - IMPORTANT / YOU MUST used sparingly (advisory).
+
+    GC-build/test/lint/precommit skip for AGENTS.md bridge files (@import first
+    line), whose commands live in the imported file.
+
+Usage:
+    validate-claude-md.py PATH [--max-lines 150] [--human]
+
+    PATH         CLAUDE.md file, or a repo root containing CLAUDE.md.
+    --max-lines  Line limit; over it fails GC-line-count (default: 150).
+    --human      Print a readable summary to stderr instead of NDJSON.
+
+Output:
+    NDJSON on stdout: one CheckRecord per line (stable check order), then one
+    SummaryRecord. With --human: a readable report on stderr, nothing on stdout.
+
+Exit codes:
+    0  all checks passed (info/skip allowed).
+    1  one or more checks failed.
+    2  usage error (no readable path given).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Final
+
+# --------------------------------------------------------------------------- #
+# Constants
+# --------------------------------------------------------------------------- #
+
+DEFAULT_MAX_LINES: Final[int] = 150
+MAX_FILE_BYTES: Final[int] = 1_000_000
+MAX_CODE_BLOCK_LINES: Final[int] = 10
+README_OVERLAP_LINES: Final[int] = 5
+README_OVERLAP_FAIL: Final[int] = 3
+MIN_BULLET_RATIO: Final[int] = 60
+PARAGRAPH_RUN: Final[int] = 3
+TREE_LINE_THRESHOLD: Final[int] = 4
+EMPHASIS_BUDGET: Final[int] = 5
+DETAIL_SNIPPET_LEN: Final[int] = 80
+PERCENT: Final[int] = 100
+
+CHECK_FILE_EXISTS: Final[str] = "GC-file-exists"
+CHECK_LINE_COUNT: Final[str] = "GC-line-count"
+CHECK_README_DUP: Final[str] = "GC-readme-dup"
+CHECK_GENERIC: Final[str] = "GC-generic-advice"
+CHECK_TREE: Final[str] = "GC-directory-tree"
+CHECK_LONG_BLOCK: Final[str] = "GC-long-code-block"
+CHECK_BULLETS: Final[str] = "GC-bullets-ratio"
+CHECK_BUILD: Final[str] = "GC-build-command"
+CHECK_TEST: Final[str] = "GC-test-command"
+CHECK_LINT: Final[str] = "GC-lint-command"
+CHECK_PRECOMMIT: Final[str] = "GC-precommit"
+CHECK_POINTERS: Final[str] = "GC-file-pointers"
+CHECK_EMPHASIS: Final[str] = "GC-emphasis"
+
+# Stable output order.
+CHECK_ORDER: Final[tuple[str, ...]] = (
+    CHECK_FILE_EXISTS,
+    CHECK_LINE_COUNT,
+    CHECK_README_DUP,
+    CHECK_GENERIC,
+    CHECK_TREE,
+    CHECK_LONG_BLOCK,
+    CHECK_BULLETS,
+    CHECK_BUILD,
+    CHECK_TEST,
+    CHECK_LINT,
+    CHECK_PRECOMMIT,
+    CHECK_POINTERS,
+    CHECK_EMPHASIS,
+)
+
+# Map check IDs to the review-claude-md rubric tier they enforce.
+CHECK_TIER: Final[dict[str, str]] = {
+    CHECK_LINE_COUNT: "C2",
+    CHECK_README_DUP: "C4",
+    CHECK_GENERIC: "C3",
+    CHECK_LONG_BLOCK: "I7",
+    CHECK_BULLETS: "I6",
+    CHECK_BUILD: "C1",
+    CHECK_TEST: "C1",
+    CHECK_LINT: "C1",
+    CHECK_PRECOMMIT: "I5",
+    CHECK_POINTERS: "I7",
+}
+
+# Generic advice Claude already knows; case-insensitive substring match.
+GENERIC_PATTERNS: Final[tuple[str, ...]] = (
+    "write clean code",
+    "handle errors gracefully",
+    "follow best practices",
+    "use best practices",
+    "always add tests",
+    "keep code dry",
+    "use meaningful names",
+    "use descriptive variable names",
+    "write readable code",
+    "comment your code",
+    "ensure code quality",
+    "make sure to test",
+)
+
+# Result levels (string values are the NDJSON contract; names avoid S105).
+LEVEL_OK: Final[str] = "pass"
+LEVEL_FAIL: Final[str] = "fail"
+LEVEL_INFO: Final[str] = "info"
+LEVEL_SKIP: Final[str] = "skip"
+
+FENCE_RE: Final[re.Pattern[str]] = re.compile(r"^\s*```")
+HEADING_RE: Final[re.Pattern[str]] = re.compile(r"^#{1,6}\s")
+BULLET_RE: Final[re.Pattern[str]] = re.compile(r"^\s*([-*+]|\d+\.)\s")
+TABLE_ROW_RE: Final[re.Pattern[str]] = re.compile(r"^\s*\|.*\|\s*$")
+TREE_CHARS_RE: Final[re.Pattern[str]] = re.compile(r"^\s*(?:[│├└─]+|[|`+]\s?--)")
+DIR_ENTRY_RE: Final[re.Pattern[str]] = re.compile(r"^\s*[\w.\-]+/(?:\s{2,}\S.*)?\s*$")
+IMPORT_RE: Final[re.Pattern[str]] = re.compile(r"^@\S")
+POINTER_RE: Final[re.Pattern[str]] = re.compile(
+    r"`[^`]*?(?:[\w./\-]+\."
+    r"(?:py|ts|tsx|js|jsx|go|rs|rb|java|kt|c|h|cpp|md|ya?ml|toml|json|sh)"
+    r"(?::\d+)?|[\w\-]+/[\w./\-]+)[^`]*?`",
+)
+EMPHASIS_RE: Final[re.Pattern[str]] = re.compile(
+    r"\b(?:IMPORTANT|YOU MUST|NEVER|ALWAYS|CRITICAL)\b",
+)
+
+# Command-family detectors. These mirror review-claude-md's validate-commands.sh
+# so the two plugins agree on what counts as a build/test/lint/pre-commit command.
+BUILD_RE: Final[re.Pattern[str]] = re.compile(
+    r"npm run build|cargo build|go build|mvn |gradle |bazel build",
+    re.IGNORECASE,
+)
+MAKE_RE: Final[re.Pattern[str]] = re.compile(r"(?:^|[|;&`])\s*make\b", re.MULTILINE)
+TEST_RE: Final[re.Pattern[str]] = re.compile(
+    r"npm test|pytest|cargo test|go test|jest|vitest|make test|yarn test|bun test",
+    re.IGNORECASE,
+)
+LINT_RE: Final[re.Pattern[str]] = re.compile(
+    r"eslint|biome|ruff|golangci-lint|clippy|prettier|make lint|yarn lint|npm run lint",
+    re.IGNORECASE,
+)
+PRECOMMIT_RE: Final[re.Pattern[str]] = re.compile(
+    r"pre-commit|precommit|before commit|commit checklist|before pushing|pre commit",
+    re.IGNORECASE,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Records
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class CheckRecord:
+    """One validation result, emitted as a CheckRecord NDJSON line."""
+
+    check: str
+    level: str
+    detail: str
+    tier: str | None = None
+
+    @property
+    def passed(self) -> bool:
+        """Return True unless the check failed."""
+        return self.level != LEVEL_FAIL
+
+    def to_json(self) -> str:
+        """Serialize to a single NDJSON line with stable key order."""
+        obj: dict[str, object] = {
+            "kind": "check",
+            "check": self.check,
+            "pass": self.passed,
+            "level": self.level,
+        }
+        if self.tier:
+            obj["tier"] = self.tier
+        obj["detail"] = self.detail
+        return json.dumps(obj, ensure_ascii=False)
+
+
+def ok(check: str, detail: str) -> CheckRecord:
+    """Build a passing record."""
+    return CheckRecord(check, LEVEL_OK, detail, CHECK_TIER.get(check))
+
+
+def fail(check: str, detail: str) -> CheckRecord:
+    """Build a failing record."""
+    return CheckRecord(check, LEVEL_FAIL, detail, CHECK_TIER.get(check))
+
+
+def info(check: str, detail: str) -> CheckRecord:
+    """Build an advisory record that never fails the run."""
+    return CheckRecord(check, LEVEL_INFO, detail, CHECK_TIER.get(check))
+
+
+def skip(check: str, detail: str) -> CheckRecord:
+    """Build a skipped record for an unmet precondition."""
+    return CheckRecord(check, LEVEL_SKIP, detail, CHECK_TIER.get(check))
+
+
+@dataclass
+class Document:
+    """Parsed CLAUDE.md plus its repo context."""
+
+    path: Path
+    text: str = ""
+    lines: list[str] = field(default_factory=list)
+    readme: str | None = None
+
+    @property
+    def line_count(self) -> int:
+        """Return the newline count, matching review-claude-md's `wc -l`."""
+        return self.text.count("\n")
+
+
+# --------------------------------------------------------------------------- #
+# Parsing helpers
+# --------------------------------------------------------------------------- #
+
+
+def read_text(path: Path) -> str:
+    """Read a file as UTF-8 with replacement for invalid bytes."""
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+def code_blocks(lines: list[str]) -> list[tuple[int, int]]:
+    """Return (start_line, body_line_count) for each fenced block (1-based)."""
+    blocks: list[tuple[int, int]] = []
+    in_block = False
+    start = 0
+    body = 0
+    for idx, line in enumerate(lines, start=1):
+        if FENCE_RE.match(line):
+            if in_block:
+                blocks.append((start, body))
+                in_block = False
+            else:
+                in_block = True
+                start = idx
+                body = 0
+        elif in_block:
+            body += 1
+    return blocks
+
+
+def in_code_spans(lines: list[str]) -> list[bool]:
+    """Mark each line True if it sits inside a fenced code block."""
+    flags: list[bool] = []
+    in_block = False
+    for line in lines:
+        if FENCE_RE.match(line):
+            flags.append(True)
+            in_block = not in_block
+        else:
+            flags.append(in_block)
+    return flags
+
+
+def truncate(text: str, limit: int = DETAIL_SNIPPET_LEN) -> str:
+    """Trim a snippet to a fixed length for compact detail messages."""
+    return text[:limit]
+
+
+def is_bridge(lines: list[str]) -> bool:
+    """Return True if the file bridges an AGENTS.md via an @import first line."""
+    for line in lines:
+        if not line.strip():
+            continue
+        return bool(IMPORT_RE.match(line.strip()))
+    return False
+
+
+# --------------------------------------------------------------------------- #
+# Checks
+# --------------------------------------------------------------------------- #
+
+
+def check_line_count(doc: Document, max_lines: int) -> CheckRecord:
+    """Verify the file fits the length budget (matches review-claude-md C2)."""
+    n = doc.line_count
+    if n <= max_lines:
+        return ok(CHECK_LINE_COUNT, f"{n} lines, within the {max_lines}-line limit")
+    return fail(
+        CHECK_LINE_COUNT,
+        f"{n} lines exceeds the {max_lines}-line limit - split into .claude/rules/",
+    )
+
+
+def check_readme_dup(doc: Document) -> CheckRecord:
+    """Flag leading lines copy-pasted from the README."""
+    if doc.readme is None:
+        return skip(CHECK_README_DUP, "No README.md found, duplication check skipped")
+    claude_lines = [ln.strip() for ln in doc.lines if ln.strip()][:README_OVERLAP_LINES]
+    readme_lines = {ln.strip() for ln in doc.readme.splitlines() if ln.strip()}
+    shared = sum(1 for ln in claude_lines if ln in readme_lines)
+    total = len(claude_lines)
+    if shared >= README_OVERLAP_FAIL:
+        return fail(
+            CHECK_README_DUP,
+            f"{shared}/{total} leading lines copied from README - dedupe vs README",
+        )
+    return ok(CHECK_README_DUP, f"{shared}/{total} leading lines shared with README")
+
+
+def check_generic_advice(doc: Document) -> CheckRecord:
+    """Flag generic advice that adds no project-specific signal."""
+    spans = in_code_spans(doc.lines)
+    hits: list[str] = []
+    for idx, line in enumerate(doc.lines):
+        if spans[idx]:
+            continue
+        low = line.lower()
+        match = next((pat for pat in GENERIC_PATTERNS if pat in low), None)
+        if match:
+            hits.append(f"L{idx + 1}: '{match}' in \"{truncate(line.strip())}\"")
+    if hits:
+        return fail(
+            CHECK_GENERIC,
+            f"{len(hits)} generic-advice line(s) Claude knows - first: {hits[0]}",
+        )
+    return ok(CHECK_GENERIC, "No generic advice patterns found")
+
+
+def check_directory_tree(doc: Document) -> CheckRecord:
+    """Flag ASCII directory trees and file-by-file enumeration."""
+    count = 0
+    first_hit = 0
+    for idx, line in enumerate(doc.lines, start=1):
+        if TREE_CHARS_RE.match(line) or DIR_ENTRY_RE.match(line):
+            count += 1
+            first_hit = first_hit or idx
+    if count >= TREE_LINE_THRESHOLD:
+        return fail(
+            CHECK_TREE,
+            f"{count} tree/enumeration line(s) at L{first_hit} - map, not a listing",
+        )
+    return ok(CHECK_TREE, "No directory tree or file-by-file enumeration")
+
+
+def check_long_code_block(doc: Document) -> CheckRecord:
+    """Flag fenced blocks larger than the snippet budget."""
+    offenders = [b for b in code_blocks(doc.lines) if b[1] > MAX_CODE_BLOCK_LINES]
+    if offenders:
+        start, body = offenders[0]
+        return fail(
+            CHECK_LONG_BLOCK,
+            f"{len(offenders)} block(s) over {MAX_CODE_BLOCK_LINES} lines - "
+            f"first L{start} ({body} lines); use a file:line pointer",
+        )
+    return ok(CHECK_LONG_BLOCK, f"No code block exceeds {MAX_CODE_BLOCK_LINES} lines")
+
+
+def count_bullets_and_prose(doc: Document) -> tuple[int, int]:
+    """Return (bullet line count, prose line count) outside code blocks."""
+    spans = in_code_spans(doc.lines)
+    bullets = 0
+    prose = 0
+    run = 0
+    for idx, line in enumerate(doc.lines):
+        is_bullet = bool(BULLET_RE.match(line)) and not spans[idx]
+        structural = (
+            spans[idx]
+            or bool(FENCE_RE.match(line))
+            or not line.strip()
+            or bool(HEADING_RE.match(line))
+            or bool(TABLE_ROW_RE.match(line))
+            or is_bullet
+        )
+        if structural:
+            if run >= PARAGRAPH_RUN:
+                prose += run
+            run = 0
+            bullets += int(is_bullet)
+        else:
+            run += 1
+    if run >= PARAGRAPH_RUN:
+        prose += run
+    return bullets, prose
+
+
+def check_bullets_ratio(doc: Document) -> CheckRecord:
+    """Verify content is mostly bullets rather than prose paragraphs."""
+    bullets, prose = count_bullets_and_prose(doc)
+    total = bullets + prose
+    if not total:
+        return ok(CHECK_BULLETS, "No prose or bullet content to score")
+    ratio = bullets * PERCENT // total
+    detail = f"Bullet ratio {ratio}% ({bullets} bullet, {prose} prose lines)"
+    if ratio >= MIN_BULLET_RATIO:
+        return ok(CHECK_BULLETS, detail)
+    return fail(CHECK_BULLETS, f"{detail} - prefer bullets (>={MIN_BULLET_RATIO}%)")
+
+
+def check_build(doc: Document, *, bridge: bool) -> CheckRecord:
+    """Verify a build command is present (mirrors review has-build)."""
+    if bridge:
+        return skip(CHECK_BUILD, "Bridge file (@import) - commands live in AGENTS.md")
+    if BUILD_RE.search(doc.text) or MAKE_RE.search(doc.text):
+        return ok(CHECK_BUILD, "Build command found")
+    return fail(CHECK_BUILD, "No build command - list the exact build invocation")
+
+
+def check_test(doc: Document, *, bridge: bool) -> CheckRecord:
+    """Verify a test command is present (mirrors review has-test)."""
+    if bridge:
+        return skip(CHECK_TEST, "Bridge file (@import) - commands live in AGENTS.md")
+    if TEST_RE.search(doc.text):
+        return ok(CHECK_TEST, "Test command found")
+    return fail(CHECK_TEST, "No test command - include a single-test invocation")
+
+
+def check_lint(doc: Document, *, bridge: bool) -> CheckRecord:
+    """Verify a lint command is present (mirrors review has-lint)."""
+    if bridge:
+        return skip(CHECK_LINT, "Bridge file (@import) - commands live in AGENTS.md")
+    if LINT_RE.search(doc.text):
+        return ok(CHECK_LINT, "Lint command found")
+    return fail(CHECK_LINT, "No lint command - list the linter invocation")
+
+
+def check_precommit(doc: Document, *, bridge: bool) -> CheckRecord:
+    """Verify a pre-commit gate is documented (mirrors review has-precommit)."""
+    if bridge:
+        return skip(CHECK_PRECOMMIT, "Bridge file (@import) - gate lives in AGENTS.md")
+    if PRECOMMIT_RE.search(doc.text):
+        return ok(CHECK_PRECOMMIT, "Pre-commit gate documented")
+    return fail(CHECK_PRECOMMIT, "No pre-commit gate - name the pre-commit check")
+
+
+def check_pointers(doc: Document) -> CheckRecord:
+    """Report whether the file uses file:line pointers."""
+    spans = in_code_spans(doc.lines)
+    count = sum(
+        len(POINTER_RE.findall(line))
+        for idx, line in enumerate(doc.lines)
+        if not spans[idx]
+    )
+    if count:
+        return info(CHECK_POINTERS, f"{count} file pointer(s) found - good")
+    return info(CHECK_POINTERS, "No file:line pointers - reference exact locations")
+
+
+def check_emphasis(doc: Document) -> CheckRecord:
+    """Report whether emphasis markers stay within budget."""
+    spans = in_code_spans(doc.lines)
+    count = sum(
+        len(EMPHASIS_RE.findall(line))
+        for idx, line in enumerate(doc.lines)
+        if not spans[idx]
+    )
+    if count <= EMPHASIS_BUDGET:
+        return info(CHECK_EMPHASIS, f"{count} emphasis marker(s), within budget")
+    return info(CHECK_EMPHASIS, f"{count} emphasis markers - keep emphasis rare")
+
+
+# --------------------------------------------------------------------------- #
+# Orchestration
+# --------------------------------------------------------------------------- #
+
+
+def resolve_target(raw: Path) -> Path:
+    """Resolve a file or repo root to the CLAUDE.md path to validate."""
+    if raw.is_file():
+        return raw
+    if raw.is_dir():
+        candidate = raw / "CLAUDE.md"
+        if candidate.is_file():
+            return candidate
+        nested = raw / ".claude" / "CLAUDE.md"
+        if nested.is_file():
+            return nested
+        return candidate
+    return raw
+
+
+def load_document(target: Path) -> Document | None:
+    """Load the target CLAUDE.md and its sibling README, or None if missing."""
+    if not target.is_file() or target.stat().st_size > MAX_FILE_BYTES:
+        return None
+    text = read_text(target)
+    readme = None
+    readme_path = target.parent / "README.md"
+    if readme_path.is_file() and readme_path.stat().st_size <= MAX_FILE_BYTES:
+        readme = read_text(readme_path)
+    return Document(path=target, text=text, lines=text.splitlines(), readme=readme)
+
+
+def run_checks(doc: Document, max_lines: int) -> list[CheckRecord]:
+    """Run every check in stable order and return the records."""
+    bridge = is_bridge(doc.lines)
+    return [
+        ok(CHECK_FILE_EXISTS, f"Found '{doc.path.name}' ({doc.line_count} lines)"),
+        check_line_count(doc, max_lines),
+        check_readme_dup(doc),
+        check_generic_advice(doc),
+        check_directory_tree(doc),
+        check_long_code_block(doc),
+        check_bullets_ratio(doc),
+        check_build(doc, bridge=bridge),
+        check_test(doc, bridge=bridge),
+        check_lint(doc, bridge=bridge),
+        check_precommit(doc, bridge=bridge),
+        check_pointers(doc),
+        check_emphasis(doc),
+    ]
+
+
+def summary_record(records: list[CheckRecord]) -> str:
+    """Build the trailing SummaryRecord NDJSON line."""
+    passed = sum(1 for r in records if r.level == LEVEL_OK)
+    failed = sum(1 for r in records if r.level == LEVEL_FAIL)
+    skipped = sum(1 for r in records if r.level == LEVEL_SKIP)
+    informational = sum(1 for r in records if r.level == LEVEL_INFO)
+    obj: dict[str, object] = {
+        "kind": "summary",
+        "total": len(records),
+        "passed": passed,
+        "failed": failed,
+    }
+    if skipped:
+        obj["skipped"] = skipped
+    if informational:
+        obj["info"] = informational
+    return json.dumps(obj, ensure_ascii=False)
+
+
+def emit_ndjson(records: list[CheckRecord]) -> None:
+    """Print every record followed by the summary as NDJSON on stdout."""
+    for record in records:
+        print(record.to_json())
+    print(summary_record(records))
+
+
+def emit_human(records: list[CheckRecord], target: Path) -> None:
+    """Print a readable verdict report on stderr."""
+    glyph = {
+        LEVEL_OK: "PASS",
+        LEVEL_FAIL: "FAIL",
+        LEVEL_INFO: "INFO",
+        LEVEL_SKIP: "SKIP",
+    }
+    print(f"CLAUDE.md validation: {target}", file=sys.stderr)
+    for record in records:
+        tier = f" [{record.tier}]" if record.tier else ""
+        line = f"  [{glyph[record.level]}]{tier} {record.check}: {record.detail}"
+        print(line, file=sys.stderr)
+    failed = sum(1 for r in records if r.level == LEVEL_FAIL)
+    verdict = "PASS" if failed == 0 else f"FAIL ({failed} failing check(s))"
+    print(f"Verdict: {verdict}", file=sys.stderr)
+
+
+def parse_args(argv: list[str] | None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description="Validate a generated CLAUDE.md")
+    parser.add_argument("path", help="CLAUDE.md file or repo root containing it")
+    parser.add_argument("--max-lines", type=int, default=DEFAULT_MAX_LINES)
+    parser.add_argument("--human", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Validate the target file and emit results; return the exit code."""
+    args = parse_args(argv)
+    target = resolve_target(Path(args.path))
+    if not target.is_file() and not target.parent.is_dir():
+        print(f"error: path not found: {args.path}", file=sys.stderr)
+        return 2
+
+    doc = load_document(target)
+    if doc is None:
+        records = [fail(CHECK_FILE_EXISTS, f"CLAUDE.md not found at '{target}'")]
+    else:
+        records = run_checks(doc, args.max_lines)
+
+    if args.human:
+        emit_human(records, target)
+    else:
+        emit_ndjson(records)
+    return 1 if any(r.level == LEVEL_FAIL for r in records) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/codex/generate-claude-md/SKILL.md
+++ b/codex/generate-claude-md/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: generate-claude-md
+description: Generate a lean, high-signal `CLAUDE.md` for a repository by reusing the source workflow under `claude/generate-claude-md`. Use when the user wants a CLAUDE.md created or refreshed in Codex.
+metadata:
+  short-description: Generate a lean CLAUDE.md for a repo
+---
+
+# Generate CLAUDE.md
+
+Use this skill when the user wants a `CLAUDE.md` file created, scaffolded, or
+refreshed for a repository from codebase analysis.
+
+This is a thin Codex wrapper around
+`claude/generate-claude-md/skills/generate-claude-md/SKILL.md`. Reuse the source
+workflow, references, and validator from the Claude skill directory instead of
+maintaining duplicated Codex copies.
+
+## Use This Skill
+
+- Use this skill when the user wants a `CLAUDE.md` generated or refreshed for a project.
+
+## Do Not Use This Skill
+
+- Do not use this skill to audit an existing CLAUDE.md against a checklist — that is `review-claude-md`.
+- Do not use this skill for generic markdown authoring unrelated to CLAUDE.md.
+
+## Source Material
+
+- Source skill: `claude/generate-claude-md/skills/generate-claude-md/SKILL.md`
+- Source directory: `claude/generate-claude-md/skills/generate-claude-md/`
+- Codex metadata: `agents/openai.yaml`
+
+Load only the source files needed for the current task. Do not recreate or copy the
+Claude-side bundled resources into this Codex skill.
+
+## Workflow
+
+1. Treat `claude/generate-claude-md/skills/generate-claude-md/SKILL.md` as the source workflow.
+2. Read the needed source references from `claude/generate-claude-md/skills/generate-claude-md/references/` (principles, section guide, scan spec, modularization, example).
+3. Run the source validator `claude/generate-claude-md/skills/generate-claude-md/scripts/validate-claude-md.py` instead of duplicating it.
+4. Apply the deletion test to every line; produce a short, project-specific file.
+
+## Codex Notes
+
+- Ignore Claude-only frontmatter and runtime wiring such as `allowed-tools`, `context: fork`, `$ARGUMENTS`, and `CLAUDE_SKILL_DIR`.
+- Infer the repo root and flags from the user request and local context before asking follow-up questions.
+- Write safety: never overwrite an existing `CLAUDE.md` unless the user was explicit; otherwise write `CLAUDE.generated.md` and report.
+- If a source script fails because of sandbox restrictions, rerun it with escalation and a short justification.
+
+## Verification
+
+After generating, run the source validator on the written file and report the verdict.
+
+1. Run `validate-claude-md.py <target> --human` and read the result.
+2. Fix any `[FAIL]` check and re-run, up to a few rounds.
+3. Report what was verified, the final line count, and any residual risk.
+
+## Examples
+
+<example>
+User: "Use Generate CLAUDE.md for this repo."
+Assistant: Opens `claude/generate-claude-md/skills/generate-claude-md/SKILL.md`, scans the codebase, synthesizes a lean CLAUDE.md, validates it, and reports.
+</example>
+
+<example>
+User: "Make a CLAUDE.md for this project."
+Assistant: Reuses the source material from `claude/generate-claude-md/skills/generate-claude-md/`, writes a short project-specific file, and runs the validator before reporting.
+</example>

--- a/codex/generate-claude-md/agents/openai.yaml
+++ b/codex/generate-claude-md/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Generate CLAUDE.md"
+  short_description: "Generate a lean CLAUDE.md for a repo"
+  default_prompt: "Use $generate-claude-md to analyze this repository and write a lean, high-signal CLAUDE.md, then validate it."

--- a/plugins/generate-claude-md/.codex-plugin/plugin.json
+++ b/plugins/generate-claude-md/.codex-plugin/plugin.json
@@ -1,0 +1,39 @@
+{
+  "name": "generate-claude-md",
+  "version": "0.1.0",
+  "description": "Generate a lean, high-signal CLAUDE.md from codebase analysis",
+  "author": {
+    "name": "Marcin Skalski",
+    "email": "marcin.skalski@example.com",
+    "url": "https://github.com/smykla-skalski"
+  },
+  "homepage": "https://github.com/smykla-skalski/sai",
+  "repository": "https://github.com/smykla-skalski/sai",
+  "license": "MIT",
+  "keywords": [
+    "codex",
+    "skills",
+    "agentic-workflows",
+    "generate-claude-md"
+  ],
+  "skills": "../../codex/generate-claude-md",
+  "interface": {
+    "displayName": "Generate CLAUDE.md",
+    "shortDescription": "Generate a lean, high-signal CLAUDE.md from codebase analysis",
+    "longDescription": "Generate CLAUDE.md from the SAI Codex collection.",
+    "developerName": "SAI",
+    "category": "Developer Tools",
+    "capabilities": [
+      "Interactive"
+    ],
+    "websiteURL": "https://github.com/smykla-skalski/sai",
+    "privacyPolicyURL": "https://github.com/smykla-skalski/sai/blob/main/README.md",
+    "termsOfServiceURL": "https://github.com/smykla-skalski/sai/blob/main/LICENSE",
+    "defaultPrompt": [
+      "Use $generate-claude-md for this task.",
+      "Open the Generate CLAUDE.md skill and apply it to the current request.",
+      "Run the Generate CLAUDE.md workflow and summarize the outcome."
+    ],
+    "brandColor": "#2563EB"
+  }
+}


### PR DESCRIPTION
# Summary

- Adds `generate-claude-md` — a plugin that generates a lean, high-signal CLAUDE.md for a repo from codebase analysis. The generator counterpart to `review-claude-md`.

## Motivation

CLAUDE.md quality drives agent effectiveness, but the built-in `/init` and the existing 690-line generator tend to produce bloated files (directory trees, README duplication, generic advice) — patterns Anthropic's docs and empirical studies (Santos et al.; the Agent READMEs study; the AGENTS.md efficiency study) show *reduce* task success. This plugin generates the lean inverse and is built to pass the sibling `review-claude-md` audit, giving the repo a matched generate ↔ review pair.

## Implementation information

- **Workflow** (`SKILL.md`, forked + fully automated): scan codebase via subagent → verify commands are real → synthesize applying the deletion test to every line → modularize into `.claude/rules/` when over 150 lines → validate and iterate to PASS.
- **Bundled validator** (`validate-claude-md.py`, ruff `select=ALL` clean, NDJSON): enforces line count, README de-duplication, no generic advice, no directory tree, code-block length, bullet ratio, and build/test/lint/pre-commit presence — mirroring `review-claude-md`'s checks (including all Critical), so a passing file cannot earn a review FAIL. Command checks skip for AGENTS.md bridge files.
- **Non-destructive**: never overwrites an existing CLAUDE.md without `--force` (writes `CLAUDE.generated.md`), honoring File-safety deterministically since a forked skill cannot prompt.
- Five reference files (principles, section-guide, scan-spec, modularization, worked example) sourced to the real best-practices literature.
- Codex surface (`codex/`, `plugins/`) + both marketplace registrations + root README entry.
- Adversarially reviewed by two agents and cross-validated: a generated file passes both this validator and `review-claude-md`'s structure + command checks.

## Supporting documentation

- [Anthropic — CLAUDE.md best practices](https://code.claude.com/docs/en/best-practices)
- [Anthropic — Memory](https://code.claude.com/docs/en/memory)