### PR TITLE
feat(skills): codex + copilot subagent delegation

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,14 @@ claude --plugin-dir /path/to/sai/claude/test-writer
 # Copilot CLI can load the same self-contained plugin directories directly.
 copilot --plugin-dir /path/to/sai/claude/staff-code-review
 
-# Council and Refactor Council also have dedicated multi-surface bundles.
+# Skills with agent fan-out also have dedicated multi-surface bundles
+# that ship native Copilot reviewer agents (sequential delegation by default).
 copilot --plugin-dir /path/to/sai/plugins/council
 copilot --plugin-dir /path/to/sai/plugins/refactor-council
+copilot --plugin-dir /path/to/sai/plugins/staff-code-review
+copilot --plugin-dir /path/to/sai/plugins/plan-critic
+copilot --plugin-dir /path/to/sai/plugins/ai-daily-digest
+copilot --plugin-dir /path/to/sai/plugins/review-claude-md
 ```
 
 ## Plugins

--- a/codex/ai-daily-digest/SKILL.md
+++ b/codex/ai-daily-digest/SKILL.md
@@ -29,10 +29,18 @@ Load only the source files needed for the current task. Do not recreate or copy 
 
 ## Workflow
 
-1. Treat `claude/ai-daily-digest/skills/ai-daily-digest/SKILL.md` as the source workflow and adapt it to Codex conventions.
+1. Treat `claude/ai-daily-digest/skills/ai-daily-digest/SKILL.md` as the source workflow and adapt it to Codex conventions. Where it spawns a research subagent per phase, run those per the "Codex execution notes" below - inline by default.
 2. When the source skill refers to bundled references, read them from `claude/ai-daily-digest/skills/ai-daily-digest/references/` as needed.
 3. Because this task depends on current events, browse for up-to-date sources before drafting and use concrete dates in the result.
 4. Keep publication to Notion or another sink as a separate step after the digest content is correct.
+
+## Codex execution notes - subagent spawning
+
+The source workflow spawns a Claude `Agent` research subagent per phase (or per batch of independent phases). Codex subagent fan-out is fragile - as of mid-2026 the default `agents.max_threads` is **6**, completed subagents do not free their slot unless explicitly closed ([openai/codex#22779](https://github.com/openai/codex/issues/22779)), and subagents can finish without returning their payload ([#16051](https://github.com/openai/codex/issues/16051)). Therefore:
+
+- **Default: sequential / inline.** Run each research phase yourself in turn - browse and gather sources, hold the findings in context, move to the next phase - then synthesize the digest. This sidesteps the thread cap and the slot-leak and handoff bugs.
+- **Optional parallel mode (only if the user asks and has raised `agents.max_threads`).** Fan out only independent phases, cap concurrency at **<= 5**, **`close_agent` each research agent as soon as it returns** (completion alone does not free the slot), and **verify each returned its sources** before synthesizing - re-run any missing one inline. Never assume all spawned agents reported.
+- Use native agent tools only for agent state (`spawn_agent` / `wait_agent` / `close_agent`); do not run nested `codex exec`, and do not use shell for agent orchestration.
 
 ## Codex Notes
 

--- a/codex/gh-review-comments/SKILL.md
+++ b/codex/gh-review-comments/SKILL.md
@@ -35,10 +35,16 @@ Before any script call:
 
 ## Script directory
 
-Use this concrete skill path:
+Resolve `SKILL_DIR` to this skill's own directory (the folder that holds `scripts/`). Do not hardcode another machine's absolute path:
 
 ```bash
-SKILL_DIR="/Users/bart.smykla@konghq.com/Projects/github.com/smykla-skalski/sai/codex/gh-review-comments"
+# From a sai checkout the repo-relative path works; otherwise locate the installed
+# copy under the Codex plugins cache.
+SKILL_DIR="codex/gh-review-comments"
+if [ ! -d "$SKILL_DIR/scripts" ]; then
+  found="$(find "${CODEX_HOME:-$HOME/.codex}/plugins" -type f -name list-threads.sh -path '*gh-review-comments*' 2>/dev/null | head -n1)"
+  [ -n "$found" ] && SKILL_DIR="$(dirname "$(dirname "$found")")"
+fi
 ```
 
 Run scripts from that directory so behavior is consistent:

--- a/codex/git-clean-gone/SKILL.md
+++ b/codex/git-clean-gone/SKILL.md
@@ -40,6 +40,7 @@ Load only the source files needed for the current task. Do not recreate or copy 
 - Infer inputs from the user request and local context before asking follow-up questions.
 - If a source script or networked command fails because of sandbox restrictions, rerun it with escalation and a short justification.
 - For destructive or irreversible actions, confirm intent unless the user was already explicit.
+- This skill runs in a single Codex agent loop - no subagent fan-out. If the source workflow spawns helper or persona subagents, do that work inline in the main loop.
 
 ## Verification
 

--- a/codex/git-stage-hunk/SKILL.md
+++ b/codex/git-stage-hunk/SKILL.md
@@ -40,6 +40,7 @@ Load only the source files needed for the current task. Do not recreate or copy 
 - Infer inputs from the user request and local context before asking follow-up questions.
 - If a source script or networked command fails because of sandbox restrictions, rerun it with escalation and a short justification.
 - For destructive or irreversible actions, confirm intent unless the user was already explicit.
+- This skill runs in a single Codex agent loop - no subagent fan-out. If the source workflow spawns helper or persona subagents, do that work inline in the main loop.
 
 ## Verification
 

--- a/codex/go-code-review/SKILL.md
+++ b/codex/go-code-review/SKILL.md
@@ -40,6 +40,7 @@ Load only the source files needed for the current task. Do not recreate or copy 
 - Infer inputs from the user request and local context before asking follow-up questions.
 - If a source script or networked command fails because of sandbox restrictions, rerun it with escalation and a short justification.
 - For destructive or irreversible actions, confirm intent unless the user was already explicit.
+- This skill runs in a single Codex agent loop - no subagent fan-out. If the source workflow spawns helper or persona subagents, do that work inline in the main loop.
 
 ## Verification
 

--- a/codex/humanize/SKILL.md
+++ b/codex/humanize/SKILL.md
@@ -40,6 +40,7 @@ Load only the source files needed for the current task. Do not recreate or copy 
 - Infer inputs from the user request and local context before asking follow-up questions.
 - If a source script or networked command fails because of sandbox restrictions, rerun it with escalation and a short justification.
 - For destructive or irreversible actions, confirm intent unless the user was already explicit.
+- This skill runs in a single Codex agent loop - no subagent fan-out. If the source workflow spawns helper or persona subagents, do that work inline in the main loop.
 
 ## Verification
 

--- a/codex/kubecon-cfp/SKILL.md
+++ b/codex/kubecon-cfp/SKILL.md
@@ -40,6 +40,7 @@ Load only the source files needed for the current task. Do not recreate or copy 
 - Infer inputs from the user request and local context before asking follow-up questions.
 - If a source script or networked command fails because of sandbox restrictions, rerun it with escalation and a short justification.
 - For destructive or irreversible actions, confirm intent unless the user was already explicit.
+- This skill runs in a single Codex agent loop - no subagent fan-out. If the source workflow spawns helper or persona subagents, do that work inline in the main loop.
 
 ## Verification
 

--- a/codex/plan-critic/SKILL.md
+++ b/codex/plan-critic/SKILL.md
@@ -29,10 +29,18 @@ Load only the source files needed for the current task. Do not recreate or copy 
 
 ## Workflow
 
-1. Treat `claude/plan-critic/skills/plan-critic/SKILL.md` as the source workflow and adapt any Claude-only delegation instructions to Codex rules.
+1. Treat `claude/plan-critic/skills/plan-critic/SKILL.md` as the source workflow. It spawns a grounding Explore agent and three parallel persona subagents (Skeptic, Architect, Verifier); run them per the "Codex execution notes" below - inline by default - instead of copying Claude's `Agent` / `subagent_type` calls.
 2. Read `claude/plan-critic/skills/plan-critic/references/personas.md` before writing the critique.
 3. Challenge hidden assumptions, missing rollback steps, and weak validation plans.
 4. Separate blockers from improvements so the user can act on the critique.
+
+## Codex execution notes - subagent spawning
+
+The source workflow uses Claude's `Agent` tool: a Phase 2 Explore agent for the Grounding Brief and three parallel persona subagents (Skeptic, Architect, Verifier) in Phase 3. Codex subagent fan-out is fragile - as of mid-2026 the default `agents.max_threads` is **6**, completed subagents do not free their slot unless explicitly closed ([openai/codex#22779](https://github.com/openai/codex/issues/22779)), and subagents can finish without returning their payload ([#16051](https://github.com/openai/codex/issues/16051)). Therefore:
+
+- **Default: sequential / inline.** Build the Grounding Brief yourself (grep/read), then adopt the Skeptic, Architect, and Verifier lenses in turn from `references/personas.md`, then synthesize the Approve/Reject/Refine verdict. This is the reliable Codex path and keeps all three personas grounded in the same brief.
+- **Optional parallel mode (only if the user asks and has raised `agents.max_threads`).** Three personas fit under a raised cap; still **`close_agent` each as soon as it returns** (completion alone does not free the slot) and **verify each returned a payload** before synthesizing - re-run any missing one inline. Never assume all spawned personas reported.
+- Use native agent tools only for agent state (`spawn_agent` / `wait_agent` / `close_agent`); do not run nested `codex exec`, and do not use shell for agent orchestration.
 
 ## Codex Notes
 

--- a/codex/promptgen/SKILL.md
+++ b/codex/promptgen/SKILL.md
@@ -53,6 +53,7 @@ Load only the source files needed for the current task. Do not recreate or copy 
 - Do not copy to clipboard unless the user explicitly asks for that side effect in the Codex session.
 - If a source script or networked command fails because of sandbox restrictions, rerun it with escalation and a short justification.
 - For destructive or irreversible actions, confirm intent unless the user was already explicit. Default Codex behavior: pause only for actions that risk data loss, security boundaries, or external impact.
+- Promptgen itself runs in a single Codex agent loop. When the prompt you generate orchestrates Codex subagents (subagent briefing, three-agent harness), reflect Codex's real fan-out limits - default `agents.max_threads` 6, `close_agent` to free completed slots ([openai/codex#22779](https://github.com/openai/codex/issues/22779)), and verify each subagent returned a payload ([#16051](https://github.com/openai/codex/issues/16051)) - instead of assuming Claude-style unlimited fan-out.
 
 ## Verification
 

--- a/codex/refactor-council/SKILL.md
+++ b/codex/refactor-council/SKILL.md
@@ -49,6 +49,7 @@ Codex subagent fan-out is fragile at this council's size. As of mid-2026: the de
 
 - **Default: sequential / inline.** Do NOT fan out to one subagent per persona by default. Adopt each persona's lens in turn yourself - read the dossier, produce that persona's review in their voice, move to the next - then synthesize, then run the adversarial pass inline. This sidesteps the thread cap and the quota-leak and handoff bugs entirely, and is the reliable Codex path.
 - **Optional parallel mode (only if the user asks and has raised `agents.max_threads`).** Cap concurrency at **<= 5** so the manager thread is not starved; run the personas in batches (e.g. two waves), **`close_agent` each reviewer as soon as it returns** (completion alone does not free the slot), and **verify each reviewer actually returned a payload** before synthesizing - re-run any missing one inline. Never assume all spawned reviewers reported.
+- Use native agent tools only for agent state (`spawn_agent` / `wait_agent` / `close_agent`); do not run nested `codex exec`, and do not use shell (`ps`, `pgrep`, `ls`, `rg`) for agent orchestration.
 - Keep the adversarial pass as a final step regardless of mode; run it inline if spawning is unreliable.
 
 ## Codex Notes

--- a/codex/review-claude-md/SKILL.md
+++ b/codex/review-claude-md/SKILL.md
@@ -29,10 +29,17 @@ Load only the source files needed for the current task. Do not recreate or copy 
 
 ## Workflow
 
-1. Treat `claude/review-claude-md/skills/review-claude-md/SKILL.md` as the source workflow.
+1. Treat `claude/review-claude-md/skills/review-claude-md/SKILL.md` as the source workflow. It spawns helper subagents sequentially (repo scan, validation-script run, re-evaluation); run them per the "Codex execution notes" below - inline in the main loop.
 2. Read the needed source references from `claude/review-claude-md/skills/review-claude-md/references/`.
 3. Run the source helper scripts from `claude/review-claude-md/skills/review-claude-md/scripts/` instead of duplicating them.
 4. Report findings before fixes unless the user explicitly asked for immediate remediation.
+
+## Codex execution notes - subagent spawning
+
+The source workflow spawns Claude `Agent` helpers sequentially - an Explore agent to scan the repo, a general-purpose agent to run the validation scripts, and another to re-evaluate the fixed file. None of these need to be subagents on Codex, and Codex fan-out is fragile anyway (default `agents.max_threads` is **6**; completed subagents do not free their slot unless explicitly closed - [openai/codex#22779](https://github.com/openai/codex/issues/22779); subagents can finish without returning their payload - [#16051](https://github.com/openai/codex/issues/16051)). Therefore:
+
+- **Run every step inline in the main loop.** Do the repo scan with grep/read, run the validation scripts directly, apply fixes with the editor, then re-evaluate inline against the rubric. Do not spawn one subagent per step - the steps are sequential and share context, so inline is both simpler and more reliable.
+- Use native agent tools only for agent state (`spawn_agent` / `wait_agent` / `close_agent`); do not run nested `codex exec`, and do not use shell (`ps`, `pgrep`) for agent orchestration.
 
 ## Codex Notes
 

--- a/codex/service-mesh-debug/SKILL.md
+++ b/codex/service-mesh-debug/SKILL.md
@@ -40,6 +40,7 @@ Load only the source files needed for the current task. Do not recreate or copy 
 - Infer inputs from the user request and local context before asking follow-up questions.
 - If a source script or networked command fails because of sandbox restrictions, rerun it with escalation and a short justification.
 - For destructive or irreversible actions, confirm intent unless the user was already explicit.
+- This skill runs in a single Codex agent loop - no subagent fan-out. If the source workflow spawns helper or persona subagents, do that work inline in the main loop.
 
 ## Verification
 

--- a/codex/staff-code-review/SKILL.md
+++ b/codex/staff-code-review/SKILL.md
@@ -32,7 +32,15 @@ Load only the source files needed for the current task. Do not recreate or copy 
 1. Treat `claude/staff-code-review/skills/staff-code-review/SKILL.md` as the source workflow.
 2. Read the needed source references from `claude/staff-code-review/skills/staff-code-review/references/` before escalating findings in those dimensions.
 3. Ground the review in actual codebase context and report findings first, ordered by severity.
-4. Where the source skill suggests agent fan-out, follow Codex delegation rules instead of copying Claude-specific agent usage blindly.
+4. The source workflow fans out to many subagents (Pass 1.5 Explore brief, seven dimension personas, the Code Adversary, Pass 2.5 translation, the Findings Adversary, and a humanize pass). Run them per the "Codex execution notes" below - inline by default - rather than copying Claude's `Agent` / `subagent_type` calls.
+
+## Codex execution notes - subagent spawning
+
+The source workflow assumes Claude's `Agent` tool and named `council:*` subagent types, neither of which exists on Codex. It also fans out well past Codex's limits: a Research-Brief Explore agent, seven dimension personas, a Code Adversary, a per-persona translation pass, a Findings Adversary, and a humanize pass. Codex subagent fan-out is fragile at that size - as of mid-2026 the default `agents.max_threads` is **6**, completed subagents do not free their slot unless explicitly closed ([openai/codex#22779](https://github.com/openai/codex/issues/22779)), and subagents can finish without returning their payload ([#16051](https://github.com/openai/codex/issues/16051)). Therefore:
+
+- **Default: sequential / inline.** Do NOT spawn one subagent per dimension. Build the Research Brief yourself (grep/read), then work each dimension's checklist from `references/` in turn in its own lens, then run the Code Adversary and the Findings Adversary as inline red-team passes. The `council:*` persona types are unavailable, so apply each lens directly and emit conventional-comment format - this makes Pass 2.5 (translation) a no-op, so skip it. Humanize inline.
+- **Optional parallel mode (only if the user asks and has raised `agents.max_threads`).** Cap concurrency at **<= 5**, run the dimensions in waves, **`close_agent` each reviewer as soon as it returns** (completion alone does not free the slot), and **verify each returned a payload** before synthesizing - re-run any missing one inline. Keep both adversary passes as final inline steps. Never assume all spawned reviewers reported.
+- Use native agent tools only for agent state (`spawn_agent` / `wait_agent` / `close_agent`); do not run nested `codex exec`, and do not use shell (`ps`, `pgrep`, `ls`, `rg`) for agent orchestration.
 
 ## Codex Notes
 

--- a/codex/staff-resume/SKILL.md
+++ b/codex/staff-resume/SKILL.md
@@ -40,6 +40,7 @@ Load only the source files needed for the current task. Do not recreate or copy 
 - Infer inputs from the user request and local context before asking follow-up questions.
 - If a source script or networked command fails because of sandbox restrictions, rerun it with escalation and a short justification.
 - For destructive or irreversible actions, confirm intent unless the user was already explicit.
+- This skill runs in a single Codex agent loop - no subagent fan-out. If the source workflow spawns helper or persona subagents, do that work inline in the main loop.
 
 ## Verification
 

--- a/codex/test-writer/SKILL.md
+++ b/codex/test-writer/SKILL.md
@@ -40,6 +40,7 @@ Load only the source files needed for the current task. Do not recreate or copy 
 - Infer inputs from the user request and local context before asking follow-up questions.
 - If a source script or networked command fails because of sandbox restrictions, rerun it with escalation and a short justification.
 - For destructive or irreversible actions, confirm intent unless the user was already explicit.
+- This skill runs in a single Codex agent loop - no subagent fan-out. If the source workflow spawns helper or persona subagents, do that work inline in the main loop.
 
 ## Verification
 

--- a/plugins/ai-daily-digest/agents/digest-research-agent.agent.md
+++ b/plugins/ai-daily-digest/agents/digest-research-agent.agent.md
@@ -1,0 +1,45 @@
+---
+name: digest-research-agent
+description: AI-digest research helper for $ai-daily-digest. Spawn only inside an ai-daily-digest workflow to research one topic/phase.
+model: gpt-5.4-mini
+model_reasoning_effort: high
+tools: Read
+user-invocable: true
+---
+
+You are a **research helper** for the `ai-daily-digest` workflow. The orchestrator spawns you to research **exactly one topic or phase** and hand back clean, dated, verifiable findings. You do not assemble the digest, rank stories, or write prose - you gather and report sources. The orchestrator does synthesis.
+
+## Your mandate
+
+Given one topic/phase (and usually a date range, a focus area, and a section of search patterns from the parent):
+
+1. **Browse for current, credible sources.** Prefer primary sources (official release notes, papers, vendor blogs, maintainer posts) over aggregators and hot takes. Use the search patterns the parent supplied; do not wander outside the assigned topic.
+2. **Pin every item to a concrete publication date.** Capture the real, stated date (ISO `YYYY-MM-DD` where possible). If an item has no findable date, say so explicitly - do not guess one.
+3. **Keep the real source URL** for every item. One canonical URL per item.
+4. **Stay inside the date range.** Drop anything older than the requested window unless the parent asked for a recap.
+5. **Never fabricate.** No invented titles, dates, URLs, numbers, or quotes. If you cannot verify something, omit it or flag it - an empty, honest result beats a padded one.
+6. **Flag uncertainty.** Mark items you could not fully confirm (date unclear, paywalled, single weak source, possibly stale) so the orchestrator can verify or drop them.
+
+## Return contract
+
+First line, exactly: `## Research: <topic>`
+
+Then a flat list of dated, sourced items - one bullet each, no analysis, no ranking:
+
+```
+## Research: <topic>
+
+- **<title>** — <1-line factual summary> — <YYYY-MM-DD> — <source URL> — id: <story-id> [flag: <reason> | confirmed]
+- ...
+
+### Notes
+- <searches that returned nothing, gaps, or items dropped as stale/unverifiable>
+```
+
+Rules for the list:
+
+- `story-id`: lowercase, hyphen-separated, company/product + action + key detail (e.g. `falcon-h1r-7b-release`, `xai-20b-funding`).
+- Every item must carry a real date and a real URL, or it does not ship - move questionable items to **Notes** with the reason.
+- `[flag: ...]` on anything not fully confirmed; `[confirmed]` (or no flag) only when date and source both check out.
+- If the topic yields nothing credible in range, return the heading plus a one-line **Notes** entry saying so. Do not pad.
+- Return only this contract. No preamble, no closing chatter.

--- a/plugins/ai-daily-digest/copilot-skills/ai-daily-digest/SKILL.md
+++ b/plugins/ai-daily-digest/copilot-skills/ai-daily-digest/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: ai-daily-digest
+description: >-
+  Produce a current AI news digest from a normal Copilot session when the user
+  wants a briefing, roundup, or "what happened in AI" summary. The content
+  depends on current sources, so browse and verify dates before drafting -
+  never write the digest from memory. Not for timeless explanations of how a
+  model or technique works.
+allowed-tools:
+  - agent
+  - list_agents
+  - read_agent
+  - read
+  - shell
+---
+
+# AI Daily Digest (Copilot)
+
+Assemble a curated, current AI news briefing. The current session agent is the orchestrator: it resolves scope, gathers dated and verified sources per topic (in-session or by delegating to a bundled research agent), checks currency, and synthesizes the digest from the bundled template. Orchestration stays in-session - this skill does not fan out a swarm of agents by default.
+
+The bundled research agent is a native Copilot custom agent under `agents/` (namespaced, e.g. `ai-daily-digest:digest-research-agent`).
+
+## References (read before drafting)
+
+- [references/sources.md](references/sources.md) - source URLs and credibility tiers.
+- [references/search-patterns.md](references/search-patterns.md) - per-topic search queries and the Friday weekly-recap section.
+- [references/output-template.md](references/output-template.md) - digest structure, section guidelines, and the Length Guidelines table.
+
+## Workflow
+
+### 1. Resolve scope and topics
+
+Parse the request for the focus (technical, business, engineering, leadership, or all) and any date range. Read [references/sources.md](references/sources.md) and [references/search-patterns.md](references/search-patterns.md) to turn the focus into a concrete list of topics/phases to cover. If the day is Friday and the user wants the weekly view, enable the weekly-recap topics from the search patterns. If scope is ambiguous, ask once; otherwise default to all topics for the current day.
+
+### 2. Research (sequential by default)
+
+Gather sources for each topic/phase. Either research each topic yourself in-session (run the relevant searches, hold the dated findings), or delegate one `digest-research-agent` per topic through the `agent` tool when a topic is large or benefits from isolation. Give each delegated agent: the date range, the focus area, the relevant section of [references/search-patterns.md](references/search-patterns.md), and the agent's return contract (a list of dated, sourced items). Validate that each agent reply starts with `## Research: <topic>` and carries dates plus URLs before using it.
+
+Default to sequential, in-session research - or one research agent at a time. Copilot parallel fan-out over-parallelizes and burns AI credits; only fan out independent topics in parallel if the user explicitly asks, then run small waves (<= 5), supervise with list_agents/read_agent, and confirm each agent returned its sources before synthesizing.
+
+### 3. Verify currency
+
+Pin every candidate item to a concrete publication date and keep its source URL. Drop anything outside the requested window and anything you cannot date or verify. No item ships without a real date and a real source - prefer fewer, solid items over padding. Deduplicate items that describe the same event from different URLs.
+
+### 4. Synthesize the digest
+
+Build the briefing using [references/output-template.md](references/output-template.md): fill the template sections with the verified items, format story lines with the template's checkbox + source-link convention, pick the Top 5 across categories by impact, and check each section against the Length Guidelines table. If a section is short, return to step 2 for that topic and gather more before finishing. If the day is light, say so rather than inventing stories.
+
+### 5. Publish (separate step, after the content is correct)
+
+Publication to Notion or any other sink is a separate step performed only after the digest content is verified and correct. Confirm the destination with the user (or follow an explicitly provided target), then publish. Do not couple drafting to publishing - a correct briefing is the deliverable; the sink is downstream.
+
+## Privacy / scope
+
+This is a *current-events* skill: its value is dated, verifiable sources, so always browse before drafting and never fabricate a date, URL, or headline. It is not for timeless conceptual explanations - for "how does X work" questions, answer directly instead of running this workflow.

--- a/plugins/ai-daily-digest/copilot-skills/ai-daily-digest/references/output-template.md
+++ b/plugins/ai-daily-digest/copilot-skills/ai-daily-digest/references/output-template.md
@@ -1,0 +1,418 @@
+# Digest Output Template
+
+Use this template for generating AI daily digests.
+
+## Contents
+
+- [Template](#template)
+- [Section Guidelines](#section-guidelines)
+- [Formatting Rules](#formatting-rules)
+- [Length Guidelines](#length-guidelines)
+
+---
+
+```markdown
+# 🤖 AI Daily Digest — {YYYY-MM-DD}
+
+**Focus:** {Technical | Business | Engineering | All}
+**Coverage:** Past {N} day(s)
+**Generated:** {timestamp}
+
+---
+
+## 🔬 Technical Advances
+
+### 📄 Research Papers
+- [ ] **{Paper Title}** — {1-line summary} [[Source]({URL})]
+- ...
+
+### 🚀 Models & Releases
+- [ ] **{Model/Tool Name}** — {what it does, why it matters} [[Source]({URL})]
+- ...
+
+### 🛠️ Frameworks & Tools
+- [ ] **{Framework Name}** — {update/release details} [[Source]({URL})]
+- ...
+
+### ✍️ Indie Blogger Posts
+- [ ] **{Author}:** [{Post Title}]({URL}) — {key insight}
+- ...
+
+### 🔥 GitHub Trending AI
+- [ ] **[{repo-owner}/{repo-name}]({URL})** ⭐ {stars} — {what it does, why interesting}
+- ...
+
+### 🎬 YouTube Videos
+- [ ] **[{Video Title}]({URL})** by {Channel} — {what you'll learn, why worth watching}
+- ...
+
+---
+
+## 🧑‍💻 AI Tools for Software Engineers
+
+- [ ] **{Tool Name}** — {what it does, why useful} [[Source]({URL})]
+- ...
+
+---
+
+## 📸 AI Tools for Photo/Video
+
+- [ ] **{Tool Name}** — {what it does, who it's for} [[Source]({URL})]
+- ...
+
+---
+
+## ✍️ AI Tools for Writers & Creators
+
+- [ ] **{Tool Name}** — {what it does, key features} [[Source]({URL})]
+- ...
+
+---
+
+## 🎨 AI Tools for Designers
+
+- [ ] **{Tool Name}** — {what it does, design use case} [[Source]({URL})]
+- ...
+
+---
+
+## 🔬 AI Tools for Researchers & Academics
+
+- [ ] **{Tool Name}** — {what it does, research application} [[Source]({URL})]
+- ...
+
+---
+
+## 🎓 AI Tools for Educators
+
+- [ ] **{Tool Name}** — {what it does, educational use} [[Source]({URL})]
+- ...
+
+---
+
+## 🏥 AI Tools for Healthcare
+
+- [ ] **{Tool Name}** — {what it does, clinical application} [[Source]({URL})]
+- ...
+
+---
+
+## ⚖️ AI Tools for Legal
+
+- [ ] **{Tool Name}** — {what it does, legal use case} [[Source]({URL})]
+- ...
+
+---
+
+## 💰 AI Tools for Finance & Accounting
+
+- [ ] **{Tool Name}** — {what it does, financial application} [[Source]({URL})]
+- ...
+
+---
+
+## 🌍 AI Application Domains
+
+### 🎓 AI in Education
+- [ ] **{Development}** — {what's new, significance} [[Source]({URL})]
+
+### 🏥 AI in Healthcare & Biotech
+- [ ] **{Development}** — {breakthrough, impact} [[Source]({URL})]
+
+### 🎨 AI in Creative Industries
+- [ ] **{Development}** — {innovation, creative application} [[Source]({URL})]
+
+### 🤖 AI in Robotics & Hardware
+- [ ] **{Development}** — {robot/hardware advance} [[Source]({URL})]
+
+### 🎮 AI in Gaming
+- [ ] **{Development}** — {gaming innovation} [[Source]({URL})]
+
+### 🔬 AI in Scientific Research
+- [ ] **{Development}** — {scientific breakthrough} [[Source]({URL})]
+
+### 📱 Consumer AI Products
+- [ ] **{Product}** — {what it does, who it's for} [[Source]({URL})]
+
+---
+
+## 🛡️ AI Safety & Ethics
+
+- [ ] **{Development}** — {safety/ethics insight, implications} [[Source]({URL})]
+- ...
+
+---
+
+## 🔓 Open Source AI
+
+- [ ] **{Project/Model}** — {what's open, license, significance} [[Source]({URL})]
+- ...
+
+---
+
+## ⚡ AI Infrastructure & Hardware
+
+- [ ] **{Development}** — {hardware/infra advance, performance} [[Source]({URL})]
+- ...
+
+---
+
+## 🌐 Regional AI Developments
+
+### 🇪🇺 Europe
+- [ ] **{Development}** — {European AI news} [[Source]({URL})]
+
+### 🇨🇳 China
+- [ ] **{Development}** — {Chinese AI news} [[Source]({URL})]
+
+### 🇯🇵 Japan & 🇰🇷 Korea
+- [ ] **{Development}** — {Asian AI news} [[Source]({URL})]
+
+### 🌏 Other Regions
+- [ ] **{Development}** — {regional AI news} [[Source]({URL})]
+
+---
+
+## 💼 Business & Industry
+
+### 💰 Funding & Acquisitions
+- [ ] **{Company}** — {amount, investors, context} [[Source]({URL})]
+- ...
+
+### 📦 Product Launches
+- [ ] **{Product}** — {what it is, significance} [[Source]({URL})]
+- ...
+
+### 📈 Market Moves
+- [ ] **{Trend/Event}** — {analysis, implications} [[Source]({URL})]
+- ...
+
+---
+
+## ⚙️ Engineering Impact
+
+### 🔄 Workflow Changes
+- {How recent developments affect day-to-day engineering work}
+- ...
+
+### 🧰 Tools & Productivity
+- [ ] **{Tool}** — {integration, use case} [[Source]({URL})]
+- ...
+
+### 👥 Job Market & Skills
+- {Hiring trends, skill demands, industry shifts}
+- ...
+
+---
+
+## 👔 Leadership & Strategy
+
+### 🎯 AI Strategy
+- [ ] **{Topic}** — {insights for engineering leaders} [[Source]({URL})]
+- ...
+
+### 🏢 Org Transformation
+- {How orgs are restructuring around AI}
+- ...
+
+### 📚 Leadership Perspectives
+- [ ] **{Leader/Company}** — {key insight} [[Source]({URL})]
+- ...
+
+---
+
+## 🤯 Cool & Thought-Provoking
+
+- [ ] **{Title}** — {why it's mind-bending or makes you think} [[Source]({URL})]
+- ...
+
+---
+
+## 📊 Top 5 Stories
+
+1. **{Headline}** — {why it matters, impact assessment}
+2. **{Headline}** — {why it matters}
+3. **{Headline}** — {why it matters}
+4. **{Headline}** — {why it matters}
+5. **{Headline}** — {why it matters}
+
+## 📅 Stories You Might Have Missed
+<!-- Friday weekly recap only -->
+
+- [ ] **{Story}** — {brief summary, why notable} [[Source]({URL})]
+- ...
+
+## 🆕 New Blogs Discovered
+<!-- Friday weekly recap only -->
+
+- [ ] **{Author/Blog Name}** — [{Blog URL}]({URL}) — {what they write about, why interesting}
+- ...
+
+---
+
+## 🔗 Sources
+
+- [{Source Name}]({URL})
+- [{Source Name}]({URL})
+- ...
+
+---
+
+## 💡 Personal Takeaways
+
+### 🎯 Action Items
+- [ ] {Specific thing to try/explore}
+- [ ] {Tool to evaluate}
+- [ ] {Article to read deeper}
+
+### 🔍 Things to Explore
+- {Topic worth deeper research}
+- {Technology to experiment with}
+
+### 🔗 Connections to Current Work
+- Links to [[{existing vault note}]] — {how it connects}
+- Relevant for [[{project}]] — {why}
+
+---
+
+**Tags:** #ai-digest #daily #{focus-area}
+```
+
+---
+
+## Section Guidelines
+
+### Technical Advances
+
+- Prioritize novel research over incremental updates
+- Include paper links when available
+- Note benchmark improvements with numbers
+
+### Indie Blogger Posts
+
+- Highlight unique perspectives not in mainstream coverage
+- Include author name for attribution
+- Focus on practical insights and deep dives
+
+### GitHub Trending AI
+
+- Focus on repos gaining stars rapidly (not just high total)
+- Prioritize practical tools engineers can use
+- Include star count for context
+- Note what makes it interesting vs existing alternatives
+
+### YouTube Videos
+
+- Prioritize educational content (paper breakdowns, tutorials, deep dives)
+- Include channel name for attribution
+- Focus on videos within date range (not old content)
+- Quality signals: technical accuracy, good explanation, production quality
+- Avoid pure hype/clickbait content
+- Note video length for context (short news vs deep dive)
+
+### AI Tools for Software Engineers
+
+- Focus on tools that solve real developer problems
+- Prioritize new launches and major updates
+- Note pricing model (free/paid/freemium)
+- Include what differentiates from existing tools
+
+### AI Tools for Photo/Video
+
+- Focus on practical tools photographers/videographers can use
+- Include both desktop and mobile apps
+- Note specific use cases (portraits, landscapes, color grading, etc.)
+- Prioritize tools with free trials or accessible pricing
+
+### Business & Industry
+
+- Include funding amounts when known
+- Note valuation changes
+- Highlight strategic implications
+
+### Engineering Impact
+
+- Focus on practical, actionable insights
+- Emphasize tools engineers can use today
+- Note workflow changes and productivity gains
+
+### Leadership & Strategy
+
+- Focus on actionable insights for eng leaders
+- Include org transformation examples
+- Note strategic implications for teams
+
+### Cool & Thought-Provoking
+
+- Unusual/creative AI applications that surprise
+- Philosophical implications of recent developments
+- Demos that make you rethink what's possible
+- Unexpected connections between AI and other fields
+- "Wait, you can do THAT?" moments
+- Dystopian or utopian implications worth pondering
+
+### Top 5 Stories
+
+- Cross-category selection
+- Ranked by impact and relevance
+- Brief "why it matters" for each
+
+### Personal Takeaways
+
+- Actionable items with checkboxes
+- Connections to existing vault notes via wikilinks
+- Specific, not generic
+
+### Stories You Might Have Missed (Friday only)
+
+- Lower-profile but interesting stories
+- Community discussions worth noting
+- Smaller releases that didn't make headlines
+
+### New Blogs Discovered (Friday only)
+
+- Original content creators (not aggregators)
+- Technical depth over clickbait
+- Active posting (last 3 months)
+- Suggest adding to sources.md if quality
+
+---
+
+## Formatting Rules
+
+1. **Emojis** — Use in section headers for scannability
+2. **Bullets** — Prefer over paragraphs
+3. **Links** — Every item needs source URL
+4. **Wikilinks** — Connect to existing vault notes where relevant
+5. **Tags** — Include #ai-digest plus focus area tags
+6. **Checkboxes** — Use for action items AND all story items (newsletter curation via `- [ ]`)
+
+---
+
+## Length Guidelines
+
+| Section | Target Items |
+| --- | --- |
+| Research Papers | 3-5 |
+| Models & Releases | 2-4 |
+| Frameworks & Tools | 2-3 |
+| Indie Blogger Posts | 2-4 |
+| GitHub Trending AI | 3-5 |
+| YouTube Videos | 2-4 |
+| AI Tools for Devs | 2-4 |
+| AI Tools Photo/Video | 2-4 |
+| Funding & Acquisitions | 2-4 |
+| Product Launches | 2-3 |
+| Market Moves | 1-3 |
+| Workflow Changes | 2-3 bullets |
+| Tools & Productivity | 2-3 |
+| Job Market | 1-2 bullets |
+| AI Strategy | 1-2 |
+| Org Transformation | 1-2 bullets |
+| Leadership Perspectives | 1-2 |
+| Cool & Thought-Provoking | 2-4 |
+| Top 5 | Exactly 5 |
+| Missed Stories (Fri) | 3-5 |
+| New Blogs (Fri) | 1-3 |
+| Sources | 10-20 |
+| Action Items | 3-5 |

--- a/plugins/ai-daily-digest/copilot-skills/ai-daily-digest/references/search-patterns.md
+++ b/plugins/ai-daily-digest/copilot-skills/ai-daily-digest/references/search-patterns.md
@@ -1,0 +1,286 @@
+# Search Patterns Reference
+
+## Contents
+
+- [Core Research (Phases 2-5)](#core-research-phases-2-5)
+- [GitHub Trending (Phase 6)](#github-trending-phase-6)
+- [AI Tools by Domain (Phase 7)](#ai-tools-by-domain-phase-7)
+- [AI Application Domains (Phase 8)](#ai-application-domains-phase-8)
+- [Safety & Ethics (Phase 9)](#safety--ethics-phase-9)
+- [Open Source Ecosystem (Phase 10)](#open-source-ecosystem-phase-10)
+- [Infrastructure & Hardware (Phase 11)](#infrastructure--hardware-phase-11)
+- [Regional Developments (Phase 12)](#regional-developments-phase-12)
+- [YouTube AI Videos (Phase 13)](#youtube-ai-videos-phase-13)
+- [Cool & Thought-Provoking (Phase 14)](#cool--thought-provoking-phase-14)
+- [Newsletters & Blogs (Phase 15)](#newsletters--blogs-phase-15)
+- [Friday Weekly Recap](#friday-weekly-recap)
+
+---
+
+## Core Research (Phases 2-5)
+
+### Phase 2: Technical
+
+Search patterns:
+
+- `AI LLM breakthrough OR release site:arxiv.org {date_range}`
+- `AI model release OR launch {date_range}`
+- `LLM framework tool release {date_range}`
+- `site:huggingface.co blog {date_range}`
+- `site:openai.com blog {date_range}`
+- `site:anthropic.com news {date_range}`
+
+Collect: new model releases, research paper highlights, framework/tool updates, benchmark results.
+
+### Phase 3: Business
+
+Search patterns:
+
+- `AI startup funding OR acquisition {date_range}`
+- `AI company valuation OR investment {date_range}`
+- `site:techcrunch.com AI {date_range}`
+- `site:venturebeat.com AI {date_range}`
+- `OpenAI OR Anthropic OR Google AI business {date_range}`
+
+Collect: funding rounds, acquisitions/mergers, product launches, partnership announcements, market analysis.
+
+### Phase 4: Engineering Impact
+
+Search patterns:
+
+- `AI coding assistant OR developer tools {date_range}`
+- `AI engineering workflow productivity {date_range}`
+- `AI job market developer skills {date_range}`
+- `site:news.ycombinator.com AI OR LLM {date_range}`
+- `site:reddit.com/r/MachineLearning {date_range}`
+- `site:reddit.com/r/LocalLLaMA {date_range}`
+
+Collect: new dev tools and integrations, workflow automation updates, job market trends, community discussions.
+
+### Phase 5: Leadership
+
+Search patterns:
+
+- `AI leadership engineering management {date_range}`
+- `AI team strategy CTO VP engineering {date_range}`
+- `site:hbr.org AI leadership management`
+- `site:mckinsey.com AI leadership`
+- `AI transformation organizational change {date_range}`
+- `engineering leadership AI adoption {date_range}`
+
+Collect: AI strategy for engineering orgs, team structure changes, leadership perspectives on AI adoption, org transformation case studies.
+
+---
+
+## GitHub Trending (Phase 6)
+
+Direct fetch:
+
+- `https://github.com/trending?since=daily&spoken_language_code=en`
+- `https://github.com/trending/python?since=daily`
+- `https://github.com/trending/jupyter-notebook?since=daily`
+
+Search patterns:
+
+- `site:github.com "stars" AI LLM new {date_range}`
+- `site:github.com trending machine learning {date_range}`
+- `github AI tool "just released" OR "new release" {date_range}`
+- `site:news.ycombinator.com "Show HN" github AI {date_range}`
+
+Collect: new AI/ML repos gaining traction (100+ stars recently), framework releases, interesting tools/demos, open-source model implementations.
+
+Use `{repo-owner}-{repo-name}` as story_id. Include repos even if not brand new — check against `.covered-stories` and include if not already covered.
+
+---
+
+## AI Tools by Domain (Phase 7)
+
+For each domain below, search using the listed patterns and collect tools matching the domain's focus. Quality signals for all: actually useful (not demos), accessible pricing, active development, good reviews, clear value proposition.
+
+### Software Engineers
+
+Patterns: `AI developer tools new release`, `AI coding assistant launch`, `AI code review tool`, `AI debugging assistant`, `AI IDE plugin extension`, `AI terminal CLI tool`, `site:producthunt.com AI developer coding`
+
+Collect: coding assistants, dev tools (testing, debugging, docs), CLI tools, IDE plugins, code review tools, DevOps AI.
+
+### Photographers & Videographers
+
+Patterns: `AI photo editing tool new`, `AI video editing software`, `AI image generation photography`, `AI video upscaling enhancement`, `AI color grading tool`, `AI background removal`, `site:producthunt.com AI photo video`
+
+Collect: photo editing, video editing, color grading, background removal, image upscaling, camera apps, video generation, VFX tools.
+
+### Writers & Content Creators
+
+Patterns: `AI writing tool new`, `AI content generation platform`, `"AI for writers" OR "AI writing assistant"`, `AI copywriting tool`, `site:producthunt.com AI writing content`
+
+Collect: writing assistants, content generation platforms, SEO tools, script tools, long-form content, editing/proofreading.
+
+### Designers
+
+Patterns: `AI design tool new`, `AI Figma plugin`, `"AI for designers" tool app`, `AI logo generator OR brand design`, `AI UI UX design tool`, `site:producthunt.com AI design`
+
+Collect: design tools, Figma/Sketch plugins, logo generators, UI/UX assistants, generative design, design system automation.
+
+### Researchers & Academics
+
+Patterns: `AI research tool new`, `AI literature review OR research assistant`, `AI paper summarization tool`, `AI citation management`, `AI data analysis research`
+
+Collect: literature review tools, paper summarization, research assistants, data analysis platforms, citation management.
+
+### Educators & Teachers
+
+Patterns: `AI education tool new`, `AI tutoring platform OR adaptive learning`, `"AI for teachers"`, `AI lesson planning tool`, `AI grading assessment`, `site:producthunt.com AI education learning`
+
+Collect: tutoring platforms, adaptive learning, lesson planning, assessment/grading, curriculum design, student engagement.
+
+### Healthcare Professionals
+
+Patterns: `AI healthcare tool new`, `AI medical imaging OR diagnostics`, `"AI for doctors"`, `AI clinical decision support`, `AI EHR electronic health records`, `AI medical scribing`
+
+Collect: medical imaging, diagnostic assistance, clinical decision support, medical documentation, EHR integration.
+
+### Legal Professionals
+
+Patterns: `AI legal tool new`, `AI contract review OR analysis`, `"AI for lawyers" OR "legal tech AI"`, `AI legal research platform`, `AI document automation legal`
+
+Collect: contract review, legal research, document automation, compliance tools, case law analysis, e-discovery.
+
+### Finance & Accounting
+
+Patterns: `AI finance tool new`, `AI accounting automation`, `"AI for finance"`, `AI fraud detection financial`, `AI forecasting financial`, `site:producthunt.com AI finance fintech`
+
+Collect: accounting automation, financial forecasting, fraud detection, tax preparation, audit assistance, investment analysis.
+
+---
+
+## AI Application Domains (Phase 8)
+
+### Education
+
+Patterns: `AI education platform OR edtech`, `adaptive learning AI`, `AI tutoring breakthrough`, `AI assessment education`
+
+### Healthcare & Biotech
+
+Patterns: `AI drug discovery OR biotech`, `AI diagnostics medical breakthrough`, `AI clinical trials`, `AI protein folding OR molecular`, `AI radiology pathology imaging`
+
+### Creative Industries
+
+Patterns: `AI music generation OR composition`, `AI game development OR procedural generation`, `AI art generation breakthrough`, `AI film production OR VFX`, `AI voice cloning OR synthesis`
+
+### Robotics & Hardware
+
+Patterns: `AI robotics OR humanoid robot`, `embodied AI OR physical AI`, `robot learning OR manipulation`, `autonomous vehicle OR robotaxi`, `drone AI OR aerial robotics`
+
+### Gaming
+
+Patterns: `AI gaming NPC OR game AI`, `procedural generation AI game`, `AI game testing OR QA`, `AI esports OR competitive gaming`
+
+### Scientific Research
+
+Patterns: `AI scientific discovery OR research`, `AI lab automation`, `AI hypothesis generation`, `AI materials science OR chemistry`, `AI climate modeling OR simulation`
+
+### Consumer AI Products
+
+Patterns: `AI consumer app launch`, `AI smartphone feature OR mobile`, `site:producthunt.com AI consumer`, `AI home automation OR smart home`, `AI personal assistant device`
+
+---
+
+## Safety & Ethics (Phase 9)
+
+Patterns: `AI safety research OR alignment`, `AI ethics guidelines OR framework`, `AI regulation OR policy`, `site:anthropic.com alignment OR safety`, `AI incident OR failure`, `interpretability OR explainable AI`, `AI bias fairness`
+
+Collect: safety research, alignment breakthroughs, policy/regulation, ethics frameworks, incident reports, interpretability, bias/fairness research.
+
+---
+
+## Open Source Ecosystem (Phase 10)
+
+Patterns: `open source AI model release`, `open weights OR open source LLM`, `site:huggingface.co open source`, `AI dataset release OR open data`, `EleutherAI OR LAION OR BigScience`
+
+Collect: open source model releases, open weight models, new datasets, community projects, democratization initiatives.
+
+---
+
+## Infrastructure & Hardware (Phase 11)
+
+Patterns: `AI chip OR AI accelerator`, `GPU OR TPU OR AI compute`, `Groq OR Cerebras OR AI hardware`, `AI training infrastructure`, `model serving OR inference optimization`, `edge AI OR on-device AI`, `AI datacenter OR compute cluster`
+
+Collect: chip announcements, custom silicon, training infrastructure, model serving, inference optimization, edge AI, datacenter architecture.
+
+---
+
+## Regional Developments (Phase 12)
+
+Patterns: `European AI OR EU AI regulation`, `China AI OR Chinese AI development`, `Japan AI OR Japanese AI`, `Korea AI OR Korean AI`, `India AI development`, `Mistral OR French AI`
+
+Collect: European AI (Mistral, regulation), Chinese AI (DeepSeek, ByteDance), Japanese/Korean initiatives, Indian ecosystem, regional policy, non-US AI companies.
+
+---
+
+## YouTube AI Videos (Phase 13)
+
+Search patterns:
+
+- `AI tutorial OR explanation site:youtube.com {date_range}`
+- `LLM "large language model" site:youtube.com {date_range}`
+- `AI news OR update site:youtube.com {date_range}`
+- `"AI paper" review OR breakdown site:youtube.com {date_range}`
+- `AI coding assistant demo site:youtube.com {date_range}`
+
+Prioritize: paper breakdowns, tool demos, technical deep dives, practical tutorials. Filter out hype/clickbait. Use `youtube-{channel}-{video-slug}` as story_id.
+
+Priority channels are listed in `sources.md` under "YouTube AI Channels".
+
+---
+
+## Cool & Thought-Provoking (Phase 14)
+
+Patterns: `AI "mind-blowing" OR "incredible" demo`, `AI art OR creative unexpected`, `AI philosophical implications`, `site:reddit.com/r/singularity`, `AI ethics dilemma OR thought experiment`
+
+Collect: viral demos, creative/artistic applications, philosophical thought experiments, "wait, that's possible now?" moments, unusual cross-domain applications. Must genuinely provoke thought, not clickbait.
+
+---
+
+## Newsletters & Blogs (Phase 15)
+
+### Specific Known Sources
+
+Check high-quality sources listed in `sources.md` under "Blogs & Newsletters" and "Indie & Smaller Bloggers".
+
+Search: `site:{blog_url} {date_range}` or `site:{blog_url} 2026-02`
+
+### Broader Platform Searches (REQUIRED)
+
+Always search these platforms:
+
+- **Substack**: `site:substack.com AI OR LLM {date_range}`
+- **Medium**: `site:medium.com AI machine learning {date_range}`
+- **DEV.to**: `site:dev.to AI tutorial OR insights {date_range}`
+- **General**: `AI blog post {date_range} analysis insights`, `"AI engineering" blog post this week`
+- **Newsletters**: `"AI newsletter" OR "ML newsletter" latest issue`, `AI weekly newsletter {date_range}`
+
+When finding new quality blogs, note in digest under "🆕 New Blogs & Sources Discovered" and consider suggesting addition to sources.md.
+
+---
+
+## Friday Weekly Recap
+
+When running on Friday, enable broader research:
+
+- Extended date range: full week (7 days)
+- Additional patterns: `"this week in AI"`, `"AI weekly roundup"`, `top AI stories week`
+- Lower-tier sources: more Reddit, Twitter
+- Add "📅 Stories You Might Have Missed" section
+- Title: "Weekly Recap" instead of "Daily Digest"
+
+### Blog Discovery (Friday)
+
+Search for new indie bloggers:
+
+- `"AI blog" OR "ML blog" interesting {date_range}`
+- `site:substack.com AI machine learning`
+- `site:medium.com AI LLM practical`
+- `site:dev.to AI machine learning tutorial`
+- `HN "Show HN" AI blog`
+
+Quality signals: original content, technical depth, practical examples, posted in last 3 months.

--- a/plugins/ai-daily-digest/copilot-skills/ai-daily-digest/references/sources.md
+++ b/plugins/ai-daily-digest/copilot-skills/ai-daily-digest/references/sources.md
@@ -1,0 +1,208 @@
+# AI Digest Sources
+
+## Contents
+
+- [Research & Papers](#research--papers)
+- [Tech News](#tech-news)
+- [Blogs & Newsletters](#blogs--newsletters)
+- [Indie & Smaller Bloggers](#indie--smaller-bloggers)
+- [YouTube AI Channels](#youtube-ai-channels)
+- [Community](#community)
+- [Engineering & Dev](#engineering--dev)
+- [GitHub Trending AI](#github-trending-ai)
+- [AI Tools for Software Engineers](#ai-tools-for-software-engineers)
+- [AI Tools for Photo/Video](#ai-tools-for-photovideo)
+- [Business & Funding](#business--funding)
+- [Leadership & Strategy](#leadership--strategy)
+- [Source Tiers](#source-tiers)
+- [Fetch Priority](#fetch-priority)
+
+---
+
+## Research & Papers
+
+| Source | URL | Search Pattern |
+| --- | --- | --- |
+| arXiv AI | arxiv.org | `site:arxiv.org cs.AI OR cs.LG OR cs.CL {topic}` |
+| HuggingFace | huggingface.co | `site:huggingface.co blog OR papers` |
+| Google AI | ai.google | `site:ai.google blog OR research` |
+| DeepMind | deepmind.google | `site:deepmind.google blog` |
+| OpenAI | openai.com | `site:openai.com blog OR research` |
+| Anthropic | anthropic.com | `site:anthropic.com news OR research` |
+| MCP Blog | blog.modelcontextprotocol.io | `site:blog.modelcontextprotocol.io` |
+| Meta AI | ai.meta.com | `site:ai.meta.com blog` |
+
+## Tech News
+
+| Source | URL | Search Pattern |
+| --- | --- | --- |
+| TechCrunch | techcrunch.com/category/artificial-intelligence | `site:techcrunch.com AI OR artificial intelligence` |
+| VentureBeat | venturebeat.com/category/ai | `site:venturebeat.com AI` |
+| The Verge | theverge.com/ai-artificial-intelligence | `site:theverge.com AI` |
+| Wired | wired.com/tag/artificial-intelligence | `site:wired.com AI` |
+| Ars Technica | arstechnica.com/ai | `site:arstechnica.com AI OR machine learning` |
+| MIT Tech Review | technologyreview.com/topic/artificial-intelligence | `site:technologyreview.com AI` |
+
+## Blogs & Newsletters
+
+| Source | URL | Focus |
+| --- | --- | --- |
+| Simon Willison | simonwillison.net | LLM tooling, practical AI |
+| Latent Space | latent.space | AI engineering, deep dives |
+| The Batch | deeplearning.ai/the-batch | Weekly AI roundup |
+| Import AI | importai.substack.com | Research summaries |
+| TLDR AI | tldr.tech/ai | Daily AI digest |
+| Ben's Bites | bensbites.com | AI products, launches |
+| Ahead of AI | magazine.sebastianraschka.com | ML research |
+| AI-Weekly | ai-weekly.ai | Weekly industry roundup |
+| Radical Data Science | radicaldatascience.wordpress.com | AI news bulletin board |
+| Last Week in AI | medium.com/last-week-in-ai | Weekly research/news digest |
+| Fladgate AI Round-Up | fladgate.com/insights (search "AI") | Legal/business perspective |
+
+## Indie & Smaller Bloggers
+
+| Source | URL | Focus |
+| --- | --- | --- |
+| Lilian Weng | lilianweng.github.io | ML deep dives, tutorials |
+| Jay Alammar | jalammar.github.io | Visual ML explanations |
+| Eugene Yan | eugeneyan.com | ML systems, applied AI |
+| Chip Huyen | huyenchip.com | MLOps, AI systems |
+| Vicki Boykis | vickiboykis.com | ML engineering, industry |
+| Hamel Husain | hamel.dev | LLMs, practical AI |
+| Jeremy Howard | jeremy.howard.net | Fast.ai, practical deep learning |
+| Chris Albon | chrisalbon.com | ML notes, applied AI |
+| Sebastian Ruder | ruder.io | NLP research |
+| Andrej Karpathy | karpathy.github.io | Neural nets, AI education |
+| swyx | swyx.io | AI engineering, latent space |
+| Rachel Thomas | rachel.fast.ai | AI ethics, fast.ai |
+| François Chollet | fchollet.substack.com | Keras, AI philosophy |
+| Addy Osmani | addyo.substack.com | LLM coding workflows, Chrome DevRel |
+| R. Srinivasan | rsrini7.substack.com | AI production, Java/Python, agents |
+
+## YouTube AI Channels
+
+| Channel | URL | Focus |
+| --- | --- | --- |
+| 3Blue1Brown | youtube.com/@3blue1brown | Math/ML visualizations, deep learning |
+| Andrej Karpathy | youtube.com/@AndrejKarpathy | Neural nets, AI education |
+| Yannic Kilcher | youtube.com/@YannicKilcher | AI paper reviews, analysis |
+| Two Minute Papers | youtube.com/@TwoMinutePapers | Research highlights, quick summaries |
+| AI Explained | youtube.com/@aiexplained-official | AI news, analysis, breakdowns |
+| Fireship | youtube.com/@Fireship | Dev-focused AI content, quick tutorials |
+| Matt Wolfe | youtube.com/@maboroshi | AI tools, news roundups |
+| The AI Advantage | youtube.com/@AIAdvantage | Practical AI tutorials |
+| AI Jason | youtube.com/@AIJasonZ | AI tools, tutorials |
+| Prompt Engineering | youtube.com/@PromptEngineering | LLM practical use |
+| Sam Witteveen | youtube.com/@samwitteveen | LLM tutorials, RAG |
+| James Briggs | youtube.com/@jamesbriggs | ML/AI engineering |
+| Nicholas Renotte | youtube.com/@NicholasRenotte | Practical ML tutorials |
+| sentdex | youtube.com/@sentdex | Python ML, AI projects |
+| StatQuest | youtube.com/@statquest | Stats/ML explained simply |
+
+## Community
+
+| Source | URL | Search Pattern |
+| --- | --- | --- |
+| Hacker News | news.ycombinator.com | `site:news.ycombinator.com AI OR LLM OR GPT` |
+| r/MachineLearning | reddit.com/r/MachineLearning | `site:reddit.com/r/MachineLearning` |
+| r/LocalLLaMA | reddit.com/r/LocalLLaMA | `site:reddit.com/r/LocalLLaMA` |
+| r/artificial | reddit.com/r/artificial | `site:reddit.com/r/artificial` |
+| AI Twitter/X | twitter.com | `AI OR LLM site:twitter.com` |
+
+## Engineering & Dev
+
+| Source | URL | Focus |
+| --- | --- | --- |
+| Dev.to AI | dev.to/t/ai | Tutorials, tools |
+| Pragmatic Engineer | pragmaticengineer.com | Industry analysis |
+| Engineering Blogs | Various | Company engineering posts |
+
+## GitHub Trending AI
+
+| Source | URL | Focus |
+| --- | --- | --- |
+| GitHub Trending (all) | github.com/trending | Overall trending repos |
+| GitHub Trending Python | github.com/trending/python | Python AI/ML repos |
+| GitHub Trending Jupyter | github.com/trending/jupyter-notebook | ML notebooks |
+| GitHub Trending TypeScript | github.com/trending/typescript | AI tooling, agents |
+
+## AI Tools for Software Engineers
+
+| Source | URL | Focus |
+| --- | --- | --- |
+| Product Hunt | producthunt.com | New tool launches |
+| DevHunt | devhunt.org | Developer tools launches |
+| Console.dev | console.dev | Dev tools newsletter |
+| There's An AI For That | theresanaiforthat.com | AI tool directory |
+| Future Tools | futuretools.io | AI tool aggregator |
+| AI Tool Report | aitoolreport.com | AI tool reviews |
+
+## AI Tools for Photo/Video
+
+| Source | URL | Focus |
+| --- | --- | --- |
+| PetaPixel | petapixel.com | Photography news, AI tools |
+| Fstoppers | fstoppers.com | Photo/video tools |
+| No Film School | nofilmschool.com | Video production tools |
+| Frame.io Blog | frame.io/blog | Video workflow |
+| Topaz Labs | topazlabs.com/blog | AI photo/video enhancement |
+| Runway | runwayml.com | AI video generation |
+
+## Business & Funding
+
+| Source | URL | Search Pattern |
+| --- | --- | --- |
+| Crunchbase | crunchbase.com | `site:crunchbase.com AI funding` |
+| Fortune | fortune.com/tag/artificial-intelligence | `site:fortune.com AI` |
+| Bloomberg | bloomberg.com | `site:bloomberg.com AI artificial intelligence` |
+| Reuters | reuters.com/technology | `site:reuters.com AI technology` |
+
+## Leadership & Strategy
+
+| Source | URL | Focus |
+| --- | --- | --- |
+| HBR | hbr.org | AI leadership, management strategy |
+| McKinsey | mckinsey.com | AI transformation, org strategy |
+| MIT Sloan | sloanreview.mit.edu | Tech leadership, AI adoption |
+| Pragmatic Engineer | pragmaticengineer.com | Engineering leadership |
+| LeadDev | leaddev.com | Engineering management |
+| InfoQ | infoq.com | Tech leadership, architecture |
+| First Round Review | review.firstround.com | Startup leadership |
+
+---
+
+*Search query templates are in `search-patterns.md` (sibling file in this directory).*
+
+---
+
+## Source Tiers
+
+**Tier 1 (Primary)** — High credibility, original content
+
+- Official company blogs (OpenAI, Anthropic, Google AI)
+- arXiv papers
+- Major tech news (TechCrunch, Ars Technica)
+
+**Tier 2 (Secondary)** — Good coverage, some analysis
+
+- Newsletters (The Batch, Import AI)
+- Tech blogs (Simon Willison, Latent Space)
+- Business news (Fortune, Bloomberg)
+
+**Tier 3 (Community)** — Signal in noise, needs filtering
+
+- Hacker News
+- Reddit communities
+- Twitter/X
+
+---
+
+## Fetch Priority
+
+When time-constrained, prioritize:
+
+1. Official blog announcements (breaking news)
+2. HN front page (community signal)
+3. TechCrunch/VentureBeat (business coverage)
+4. Newsletters (curated summaries)
+5. Reddit (community discussion)

--- a/plugins/ai-daily-digest/plugin.json
+++ b/plugins/ai-daily-digest/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "ai-daily-digest",
+  "description": "Assemble a current AI news digest from a normal Copilot session. Keeps orchestration in-session: gathers dated, verified sources per topic (optionally delegating to a native research agent), then synthesizes a curated briefing. Defaults to sequential, in-session research for reliable, credit-efficient execution.",
+  "version": "0.1.0",
+  "author": { "name": "Smykla Skalski Labs" },
+  "homepage": "https://github.com/smykla-skalski/sai",
+  "repository": "https://github.com/smykla-skalski/sai",
+  "license": "MIT",
+  "keywords": ["copilot", "custom-agents", "ai-news", "digest", "research", "current-events"],
+  "category": "Developer Tools",
+  "agents": "agents/",
+  "skills": "copilot-skills/"
+}

--- a/plugins/plan-critic/agents/architect-reviewer.agent.md
+++ b/plugins/plan-critic/agents/architect-reviewer.agent.md
@@ -1,0 +1,60 @@
+---
+name: architect-reviewer
+description: Plan-critic reviewer persona for $plan-critic. Spawn only inside a plan-critic workflow.
+model: gpt-5.4-mini
+model_reasoning_effort: high
+tools: Read
+user-invocable: true
+---
+
+You are **the Architect** - a structural reviewer spawned inside a plan-critic workflow to judge whether a proposed implementation plan is *built right* before any code is written. Your job is the structural soundness of the plan: file selection, dependencies, execution order, fit with existing patterns, scope, and backward compatibility. You do **not** assess whether the author actually read the code (the Verifier owns that) or hunt for missing edge cases (the Skeptic owns that). Stay in your lane; the value of three reviewers is that each one goes deep on one axis.
+
+You receive two inputs from the orchestrator: the **full plan text** and the **Grounding Brief** (file/symbol verification, caller blast radius, existing patterns, related tests). Use your Read tool to confirm the plan's structural claims against the real code and conventions - do not approve a structure you have not checked.
+
+## Your lens - judge the structure
+
+1. **File selection.** Are the right files targeted? Are any obviously-needed files missing? Cross-reference the Grounding Brief's caller list: if a function has 23 callers and the plan updates only 3, that is a red flag, not a detail.
+2. **Execution order and dependencies.** Are the steps sequenced correctly? Will an earlier step break the build for a later one? Are there circular dependencies between steps? A plan that compiles only at the end is fragile.
+3. **Convention alignment.** Does the plan match the existing patterns surfaced in the Grounding Brief? If existing handlers use a shared `respondJSON()` helper and the plan rolls its own response writer, that is drift the plan must justify or drop.
+4. **Scope.** Is the plan focused or sprawling? Does it bundle unrelated changes into one effort? Does it touch 7+ files (context-window and review-quality risk)? Flag scope that should be split.
+5. **Backward compatibility.** Does the plan change a signature, schema, or contract that existing callers depend on without a migration or shim step? Name the callers from the Grounding Brief that would break.
+
+## Voice rules
+
+- **Be specific and falsifiable.** "Step 2 renames `Persist` but the Grounding Brief lists 23 callers and the plan updates 3 - the build breaks at the other 20." Not "watch out for callers."
+- **Critique the structure, don't redesign the system.** You flag the structural fault and what it risks; you do not author a replacement plan. That is the orchestrator's job.
+- **Prefer reorder over reject when the bones are sound.** If the approach is valid but the sequencing or scope is off, say so and point at the fix shape rather than condemning the whole plan.
+- **Ground every claim.** Tie each finding to a file, symbol, caller, or pattern from the plan or the Grounding Brief, confirmed against the code you Read.
+
+## Required output contract
+
+Your first response line must be exactly `## Architect review`. Return exactly this structure, no preamble:
+
+```
+## Architect review
+
+### Verdict
+<One line: APPROVE (structure is sound) | REFINE (structural fixes below are
+required first) | REJECT (the structure is fundamentally wrong and must be
+re-planned).>
+
+### File selection issues
+<Bullets: missing or extraneous files, each with rationale and the caller/pattern
+evidence. Empty only if selection is clean.>
+
+### Order and dependency issues
+<Bullets: specific sequencing problems, build-breaking step orders, or circular
+dependencies, with the corrected order where you can give it.>
+
+### Convention drift
+<Bullets: where the plan diverges from existing patterns in the Grounding Brief,
+naming the convention it should follow.>
+
+### Scope and backward compatibility
+<Bullets: scope that should be split (e.g. 7+ files, bundled unrelated changes) and
+any contract/signature/schema break against existing callers, with a migration note.>
+
+### Evidence I checked
+<1-2 sentences: what you actually Read and verified vs what you took from the plan
+or Grounding Brief on its word.>
+```

--- a/plugins/plan-critic/agents/skeptic-reviewer.agent.md
+++ b/plugins/plan-critic/agents/skeptic-reviewer.agent.md
@@ -1,0 +1,61 @@
+---
+name: skeptic-reviewer
+description: Plan-critic reviewer persona for $plan-critic. Spawn only inside a plan-critic workflow.
+model: gpt-5.4-mini
+model_reasoning_effort: high
+tools: Read
+user-invocable: true
+---
+
+You are **the Skeptic** - an adversarial gap-finder spawned inside a plan-critic workflow to stress-test a proposed implementation plan *before* any code is written. Your single job is to find what is missing, what edge cases are unhandled, and what will break in production. You are not here to praise a plan; you are here to make it fail on paper so it does not fail in production. Default to suspicion: a plan earns trust only when it has answered the questions you would ask.
+
+You receive two inputs from the orchestrator: the **full plan text** and the **Grounding Brief** (file/symbol verification, caller blast radius, existing patterns, related tests). Read the actual code with your Read tool to confirm or refute the plan's claims - do not take the plan on faith, and do not take the Grounding Brief on faith where you can check it yourself.
+
+## Your lens - hunt for the hidden
+
+For the plan in front of you, interrogate every axis:
+
+1. **Missing requirements.** What does the plan fail to address that the user clearly needs? Re-read the user's original request (if available) and look for the gap between what was asked and what the plan covers.
+2. **Edge cases.** For every code path the plan introduces or modifies, ask: empty input? null? concurrent access? error from downstream? partial failure? What does the plan say about each? Silence is a gap, not a pass.
+3. **Failure modes and rollback.** What happens if the change is only half-applied? What is the rollback story? Is there a migration that can fail mid-flight and leave the system in a broken state? A plan with no rollback path for a risky change is itself a risk.
+4. **Test gaps.** Does the plan add tests, and for what? Cross-check the Grounding Brief's related-tests section - does the plan ignore a coverage gap the Brief already surfaced?
+5. **Verification criteria.** How will anyone know the change worked? Demand a concrete success criterion per step (a named test passes, a command outputs X, an endpoint returns Y). Without it, the plan produces code that "looks right but doesn't work."
+
+## Voice rules
+
+- **Be specific and falsifiable.** "Step 3 writes to the cache but never invalidates it on the error path in `handler/api.go:88` - stale reads after a failed write." Not "error handling seems weak."
+- **Name the missing thing, don't redesign it.** You surface the gap and the risk; you do not rewrite the plan. Authorship is the orchestrator's job.
+- **Treat absence as evidence.** If the plan is silent on rollback, tests, or an edge case, that silence is a finding - state it.
+- **Ground every claim.** Tie findings to a file, symbol, caller, or test from the plan or the Grounding Brief, and Read the code to confirm before you assert.
+
+## Required output contract
+
+Your first response line must be exactly `## Skeptic review`. Return exactly this structure, no preamble:
+
+```
+## Skeptic review
+
+### Verdict
+<One line: APPROVE (no critical gaps) | REFINE (specific gaps must be closed first,
+listed below) | REJECT (the plan is missing so much it must be re-planned).>
+
+### Critical gaps
+<Bullets: things that will cause problems if not addressed, each tied to a step,
+file, or symbol. Empty only if you genuinely found none.>
+
+### Edge cases unhandled
+<Bullets: specific scenarios (empty/null/concurrent/downstream-error/partial-failure)
+the plan does not cover, each naming the code path it affects.>
+
+### Missing verification criteria
+<Bullets: for each step lacking a concrete success criterion, state what "done"
+should mean (named test passes, command output, endpoint response).>
+
+### Things that could go wrong
+<Bullets: failure modes, rollback gaps, mid-flight migration risks, and a rough
+likelihood for each.>
+
+### Evidence I checked
+<1-2 sentences: what you actually Read and verified vs what you took from the plan
+or Grounding Brief on its word.>
+```

--- a/plugins/plan-critic/agents/verifier-reviewer.agent.md
+++ b/plugins/plan-critic/agents/verifier-reviewer.agent.md
@@ -1,0 +1,58 @@
+---
+name: verifier-reviewer
+description: Plan-critic reviewer persona for $plan-critic. Spawn only inside a plan-critic workflow.
+model: gpt-5.4-mini
+model_reasoning_effort: high
+tools: Read
+user-invocable: true
+---
+
+You are **the Verifier** - a grounding reviewer spawned inside a plan-critic workflow with one question to answer about a proposed implementation plan: *did the author actually read the code, or did it skim file names?* A plan that names files generically has not been read. A plan that references `verify_jwt_token` at `auth/middleware.go:42` has been read. Your job is to tell those apart and force the second. You do **not** judge structure (the Architect owns that) or hunt missing edge cases (the Skeptic owns that).
+
+You receive two inputs from the orchestrator: the **full plan text** and the **Grounding Brief** (file/symbol verification, caller blast radius, existing patterns, related tests). The Grounding Brief is your ground truth - when the plan claims `X exists` and the Brief says `X not found`, the Brief wins, because plans hallucinate and greps do not. Use your Read tool to spot-check the code directly where it sharpens or settles a question.
+
+## Your lens - measure the reading, not the writing
+
+1. **Function/symbol specificity.** Does the plan reference specific function names, type names, or line numbers? Or only file names and vague descriptions ("the auth system", "the user module")? Generic references are evidence of skimming.
+2. **Cross-check against the Grounding Brief.** Are the symbols the plan names actually present in the codebase? Does the plan misname any - e.g. `UserStore.Save` when the real symbol is `UserRepository.Persist` at `store/user.go:118`? Each misnamed symbol is a hole in the plan's foundation.
+3. **Architectural awareness.** Does the plan show it understands *how* the code works (the middleware chain, the data flow, error propagation), or only *that* code exists in those files? Naming a file is not understanding it.
+4. **Hidden assumptions.** What is the plan assuming about the code that it has not verified? ("the existing handler returns an error" - does it actually?) List each unverified assumption; these are the cracks a confident-looking plan hides.
+
+## Voice rules
+
+- **Be specific and falsifiable.** "The plan says it updates `UserStore.Save`, but the Grounding Brief and `store/user.go:118` show the symbol is `UserRepository.Persist` - the plan never opened this file." Not "the plan seems shallow."
+- **Quote the plan as evidence.** Cite the exact phrases that prove (or fail to prove) the code was read. A depth claim without a quote is just an opinion.
+- **Diagnose depth, don't rewrite the plan.** You report whether reading happened and what must be read before the plan can be trusted; you do not author the corrected plan.
+- **Trust greps over prose.** Where plan claims and the Grounding Brief conflict, the Brief and the code you Read win every time.
+
+## Required output contract
+
+Your first response line must be exactly `## Verifier review`. Return exactly this structure, no preamble:
+
+```
+## Verifier review
+
+### Verdict
+<One line: APPROVE (deep reading, symbols verified) | REFINE (specific reads/
+corrections required before trust, listed below) | REJECT (surface reading or
+hallucinated symbols - the codebase must be re-read before re-planning).>
+
+### Depth score
+<Deep | Surface | Shallow - one word, then a half-sentence justification.>
+
+### Evidence of reading
+<Bullets: specific quotes from the plan that prove or fail to prove the code was
+read, each judged against the Grounding Brief or the code you Read.>
+
+### Hidden assumptions
+<Bullets: unverified assumptions the plan makes about the code's behavior, each
+naming the file/symbol that must be checked to confirm it.>
+
+### Required pre-execution reads
+<Bullets: the specific files/functions (path:line where known) the author must read
+before this plan can be trusted.>
+
+### Evidence I checked
+<1-2 sentences: what you actually Read and verified vs what you took from the plan
+or Grounding Brief on its word.>
+```

--- a/plugins/plan-critic/copilot-skills/plan-critic/SKILL.md
+++ b/plugins/plan-critic/copilot-skills/plan-critic/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: plan-critic
+description: >-
+  Critique an implementation plan from a normal Copilot session when the user
+  shares a plan (Plan Mode output, pasted plan text, or a plan file path) and wants
+  it stress-tested before any code is written. Triages the plan, grounds it against
+  the codebase, delegates to three native persona reviewers (Skeptic, Architect,
+  Verifier), and returns an Approve/Reject/Refine verdict with concrete refinements.
+  Not for executing the plan, reviewing an already-written diff, or a quick lint pass.
+allowed-tools:
+  - agent
+  - list_agents
+  - read_agent
+  - write_agent
+  - read
+---
+
+# Plan Critic (Copilot)
+
+Critique an implementation plan **before** any code is written. The cost of revising a plan is near-zero; the cost of revising executed code is hours of rework. This skill keeps orchestration in-session: the current Copilot agent triages the plan, builds one Grounding Brief from the codebase, delegates to three native persona reviewer agents, and synthesizes a single verdict. Nothing is approved until three independent personas have inspected the plan against ground truth.
+
+**Core principle:** A plan that names files generically has not been read. A plan that references `verify_jwt_token` at `auth/middleware.go:42` has been read. The job of this skill is to tell those apart and force the second.
+
+## The reviewers (3 native agents)
+
+Bundled as custom agents under `agents/` (namespaced, e.g. `plan-critic:skeptic-reviewer`). Their exact instruction blocks live in [references/personas.md](references/personas.md) - read it before Phase 3 so you brief each reviewer faithfully.
+
+| Reviewer agent | Lens |
+|---|---|
+| `skeptic-reviewer` | What's missing - hidden assumptions, edge cases, failure modes, rollback gaps, missing verification criteria |
+| `architect-reviewer` | Is it built right - file selection, execution order, convention fit, scope, backward compatibility, system impact |
+| `verifier-reviewer` | Did the author actually read the code, or skim file names - symbol specificity, cross-check vs the Grounding Brief, architectural awareness |
+
+Keep this reviewer framing internal (see Privacy / scope).
+
+## Parsing the request
+
+The user's text (or an attached file / pasted block) is the plan to review. Resolve it first: read the file if a path was given, use the inline text if pasted, or adopt the most recent plan produced in this conversation. If no plan is resolvable, ask which plan to review - do not invent one.
+
+## Workflow
+
+### Phase 1 - Triage (fast, do not delegate)
+
+Resolve the plan input, then run a fast scope check. **This phase never delegates** - if it finds a fundamental issue, report it and stop.
+
+1. **Is this actually a plan?** It must describe *what* will change and *where*, not just narrative discussion. If it has no concrete file/function/step list, ask the user to convert it into a plan first, then stop.
+2. **Plan size scan.** Count files mentioned, count distinct steps/phases, and note whether line numbers or symbol names appear.
+3. **Trivial-change escape hatch.** If the plan describes a change that fits in one sentence (typo, single-line fix, rename in one file), tell the user planning overhead is not warranted - recommend executing directly - and stop. Do not delegate to reviewers for trivial plans.
+4. **Scope warning.** If the plan touches **7 or more files**, surface this immediately: context degrades plan quality past this threshold and reviewers begin missing cross-file interactions. Recommend splitting into sub-plans before review, or proceeding only with explicit acknowledgment.
+
+If triage finds a fundamental issue (not a plan, trivial, or oversized), report and stop here.
+
+### Phase 2 - Grounding Brief (build INLINE, do not delegate)
+
+Build the **Grounding Brief yourself in the orchestrator** by grep/read over the codebase. All three reviewers share this one brief - do not delegate this phase and do not let each persona re-explore.
+
+Produce, against the real code:
+
+1. **File verification** - for every file the plan names, confirm it exists; list missing/misnamed paths.
+2. **Symbol verification** - for every function/type/symbol the plan names, locate it (`path:line`) and flag any that do not exist or are misnamed (e.g. plan says `UserStore.Save`, code has `UserRepository.Persist` at `store/user.go:118`).
+3. **Caller blast radius** - for functions the plan modifies, count callers and list 3-5 locations.
+4. **Existing patterns** - find 2-3 existing examples of the kind of change proposed (e.g. existing handlers a new handler should mirror).
+5. **Related tests** - find tests covering the modules being changed, and note coverage gaps.
+
+Grounding Brief shape:
+
+```
+## Grounding Brief
+### File verification
+### Symbol verification
+### Callers (blast radius)
+### Existing patterns
+### Related tests
+```
+
+The Brief is load-bearing - pass it verbatim to every reviewer. Trust the Brief over the plan's claims: when the plan says `X exists` and the Brief says `X not found`, the Brief wins.
+
+### Phase 3 - Reviewer delegation (sequential by default)
+
+Read [references/personas.md](references/personas.md), then delegate each reviewer through the `agent` tool, giving each one: the **full plan text**, the **Grounding Brief** from Phase 2, that persona's mandate, and the instruction that its first response line must be `## <Persona> review`. Delegate the Skeptic, then the Architect, then the Verifier.
+
+Default to sequential reviewer delegation - one agent at a time. Copilot parallel fan-out over-parallelizes and burns AI credits and offers no reliability guarantee; sequential is the reliable path. Only fan out in parallel if the user explicitly asks, then supervise with list_agents/read_agent and confirm each returned a payload before synthesizing.
+
+Validate each reviewer result: it must start with `## <Persona> review` and contain the persona's contract sections. If a result is malformed or empty, re-delegate that reviewer once with the same plan + Brief; if still malformed, continue and note the missing lens in the synthesis. Never surface raw reviewer envelopes or readiness text.
+
+### Phase 4 - Synthesis and verdict
+
+Recall the Phase 1 scope flags and the Phase 2 Grounding Brief before reading reviewer output, so the verdict stays anchored to verified evidence rather than persona assertion. Then **merge** the three reviews into one verdict - do not concatenate them:
+
+1. **Deduplicate** - if two reviewers flagged the same missing file or symbol, merge into one finding.
+2. **Separate blockers from improvements** - blocking issues first, then refinements, then nits.
+3. **Surface disagreement, don't flatten it** - if one reviewer leans APPROVE and another REJECT, present the conflict explicitly and let the user adjudicate; trust the more conservative reviewer when forced to pick.
+4. **Cross-cutting insight** - call out findings that emerge only from combining perspectives (e.g. Verifier says a file was not read + Architect says the plan ignores its 20 callers + Skeptic says no test covers the new behavior = one strong blocker).
+5. **Pick one verdict:**
+   - **APPROVE** - strategy sound, depth adequate, no critical gaps. Safe to execute.
+   - **REFINE** - on the right track but needs specific, concrete additions/corrections first. Provide an ordered refinement list (if it grows past ~5 items, switch to REJECT).
+   - **REJECT** - fundamental issues (wrong approach, missed key files, hallucinated symbols, surface reading). Must be re-planned after the author reads more code.
+
+Return findings only - do not rewrite the plan yourself; evaluation and authorship are different jobs.
+
+## Synthesis output shape
+
+```
+# Plan Review
+
+## Verdict: [APPROVE | REFINE | REJECT]
+**One-line summary:** <why, in one sentence>
+**Plan stats:** <N files, M steps, depth: Deep/Surface/Shallow>
+
+## Triage notes
+<scope/size flags from Phase 1; skip if clean>
+
+## Grounding Brief
+<the Phase 2 brief>
+
+## Findings
+<merged, deduplicated findings ranked blockers -> refinements -> nits>
+
+## Disagreement
+<where the reviewers diverged; skip if they converged>
+
+## Refinement list
+<only if REFINE: concrete, ordered changes to make before approval>
+
+## Rejection rationale
+<only if REJECT: what is fundamentally wrong and what to read before re-planning>
+
+## Next action
+<"Approved - proceed with execution." | "Refine using the list above, then re-submit."
+ | "Reject - read <files> and re-plan from scratch.">
+```
+
+## Privacy / scope
+
+The reviewer personas are internal review aids. Keep reviewer framing internal - present one synthesized verdict to the user, not three raw envelopes; if a finding leaves the team, restate it in your own voice. This skill reviews a *plan*, before code exists - it does not execute the plan, and it is not a substitute for reviewing an already-written diff (use a staff-level or language-specific code review for that).

--- a/plugins/plan-critic/copilot-skills/plan-critic/references/personas.md
+++ b/plugins/plan-critic/copilot-skills/plan-critic/references/personas.md
@@ -1,0 +1,78 @@
+# Plan Critic Personas
+
+Full review prompts for the three Phase 3 personas. Spawn each as a parallel `Agent` subagent (single message, multiple Agent tool calls). Pass each persona the full plan text **and** the Grounding Brief from Phase 2.
+
+## Persona 1: The Verifier
+
+**Subagent type:** `general-purpose`
+
+**Role:** Did Claude actually read the code, or did it skim file names?
+
+**Instructions to pass:**
+
+> You are reviewing a Claude implementation plan with one job: determine whether the plan demonstrates that Claude actually read the relevant code, or whether it is operating on surface-level guesses.
+>
+> **Inputs:** the plan text, the Grounding Brief.
+>
+> **Evaluate:**
+> 1. **Function/symbol specificity** — Does the plan reference specific function names, type names, or line numbers? Or only file names and vague descriptions ("the auth system", "the user module")? Generic references = skimming.
+> 2. **Cross-check against Grounding Brief** — Are the symbols the plan names actually present in the codebase? Does the plan misname any (e.g., `UserStore.Save` when the real symbol is `UserRepository.Persist`)?
+> 3. **Architectural awareness** — Does the plan show understanding of *how* the code works (middleware chain, data flow, error propagation), or just *that* code exists in those files?
+> 4. **Hidden assumptions** — What is the plan assuming about the code that it has not verified? (E.g., "the existing handler returns an error" — does it actually?)
+>
+> **Output:** A `## Verifier Findings` section with:
+> - **Depth score:** Deep / Surface / Shallow
+> - **Evidence of reading:** specific quotes from the plan that prove (or fail to prove) Claude read the code
+> - **Hidden assumptions:** list of unverified assumptions the plan makes
+> - **Required pre-execution reads:** files/functions Claude must read before this plan can be trusted
+
+## Persona 2: The Architect
+
+**Subagent type:** `general-purpose`
+
+**Role:** Is the structure of the plan sound? File selection, dependencies, execution order, fit with existing patterns.
+
+**Instructions to pass:**
+
+> You are reviewing a Claude implementation plan from an architect's perspective. Your job is to evaluate the structural soundness of the plan, not whether Claude read the code (that's the Verifier's job).
+>
+> **Inputs:** the plan text, the Grounding Brief.
+>
+> **Evaluate:**
+> 1. **File selection** — Are the right files targeted? Are any obviously-needed files missing? Cross-reference against the Grounding Brief's caller list — if a function has 23 callers and the plan only updates 3, that's a red flag.
+> 2. **Execution order & dependencies** — Are steps sequenced correctly? Will earlier steps break the build for later steps? Are there circular dependencies?
+> 3. **Convention alignment** — Does the plan match existing patterns surfaced in the Grounding Brief? If existing handlers use `respondJSON()` and the plan rolls its own response writer, that's drift.
+> 4. **Scope** — Is the plan focused or sprawling? Does it bundle unrelated changes? Does it touch 7+ files (context-window risk)?
+> 5. **Backward compatibility** — Does the plan break existing callers without a migration step?
+>
+> **Output:** A `## Architect Findings` section with:
+> - **Soundness verdict:** Sound / Needs revision / Fundamentally wrong
+> - **File selection issues:** missing/extra files with rationale
+> - **Order/dependency issues:** specific sequencing problems
+> - **Convention drift:** where the plan diverges from existing patterns
+> - **Scope concerns:** if applicable
+
+## Persona 3: The Skeptic
+
+**Subagent type:** `general-purpose`
+
+**Role:** What's missing? What goes wrong? Adversarial gap-finding.
+
+**Instructions to pass:**
+
+> You are reviewing a Claude implementation plan as an adversarial skeptic. Your job is to find what is missing, what edge cases are unhandled, and what will break in production.
+>
+> **Inputs:** the plan text, the Grounding Brief.
+>
+> **Evaluate:**
+> 1. **Missing requirements** — What is the plan failing to address that the user clearly needs? Re-read the user's original request (if available) and look for gaps.
+> 2. **Edge cases** — For every code path the plan introduces or modifies, ask: empty input? null? concurrent access? error from downstream? partial failure? What does the plan say about each? (Silence = a gap.)
+> 3. **Failure modes** — What happens if the change is half-applied? What's the rollback story? Is there a migration that can fail mid-flight?
+> 4. **Test gaps** — Does the plan add tests? For what? Does the Grounding Brief show coverage gaps the plan ignores?
+> 5. **Verification criteria** — How will Claude (or the user) know the change worked? Is there a concrete success criterion (test passes, command outputs X, endpoint returns Y)? Without this, Claude can produce code that "looks right but doesn't work."
+>
+> **Output:** A `## Skeptic Findings` section with:
+> - **Critical gaps:** things that *will* cause problems if not addressed
+> - **Edge cases unhandled:** specific scenarios with no plan coverage
+> - **Missing verification criteria:** what success looks like for each step
+> - **Things that could go wrong:** failure modes and their likelihood

--- a/plugins/plan-critic/plugin.json
+++ b/plugins/plan-critic/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "plan-critic",
+  "description": "Critique an implementation plan from a normal Copilot session only when explicitly requested. Keeps orchestration in-session: triages the plan, builds a grounding brief from the codebase, delegates to three native persona reviewer agents (Skeptic, Architect, Verifier), then synthesizes an Approve/Reject/Refine verdict with concrete refinements. Defaults to sequential reviewer delegation for reliable, credit-efficient execution.",
+  "version": "0.1.0",
+  "author": { "name": "Smykla Skalski Labs" },
+  "homepage": "https://github.com/smykla-skalski/sai",
+  "repository": "https://github.com/smykla-skalski/sai",
+  "license": "MIT",
+  "keywords": ["copilot", "custom-agents", "planning", "plan-review", "code-review", "architecture"],
+  "category": "Developer Tools",
+  "agents": "agents/",
+  "skills": "copilot-skills/"
+}

--- a/plugins/review-claude-md/agents/claude-md-evaluator.agent.md
+++ b/plugins/review-claude-md/agents/claude-md-evaluator.agent.md
@@ -1,0 +1,72 @@
+---
+name: claude-md-evaluator
+description: CLAUDE.md rubric evaluator for $review-claude-md. Spawn only inside a review-claude-md workflow to re-evaluate a fixed file against the rubric.
+model: gpt-5.4-mini
+model_reasoning_effort: high
+tools: Read
+user-invocable: true
+---
+
+You are a **clean-room CLAUDE.md rubric evaluator**. You are spawned only from inside a `$review-claude-md` workflow to give an independent second opinion on a CLAUDE.md file after it has been audited or fixed. You score; you do not edit. You have read-only access — never propose to apply changes yourself, only describe the fixes the orchestrator should make.
+
+## Inputs you are given
+
+The orchestrator passes you:
+
+- **CLAUDE.md path** — the file to evaluate (read it in full).
+- **The rubric** — the tiered binary checklist (Critical / Important / Polish) and its verdict logic. Treat the rubric the orchestrator supplies as authoritative; if it also hands you a path to `references/rubric.md`, read that and use it verbatim.
+- **Validation-script output** — JSON `{check, pass, detail}` lines from `validate-claudemd.sh` and `validate-commands.sh`. Trust these for the checks they cover (line count, README duplication, generic advice, long code blocks, bullet ratio, modularization, build/test/lint/pre-commit presence, command validity); do not re-run them.
+- Optionally: a codebase summary (build/test/lint/CI conventions) and the target repo root.
+
+If any input is missing, evaluate from what you have and state the gap explicitly rather than guessing.
+
+## What you do
+
+1. Read the CLAUDE.md at the given path in full.
+2. Map each Critical, Important (and Polish, if asked) check to evidence — prefer the validation-script JSON where it covers a check; otherwise judge from the file contents and codebase summary. Quote the offending line or describe the absence.
+3. Apply the rubric's verdict logic exactly: any Critical fail → NOT-PASS; 3+ Important fails → NOT-PASS; otherwise PASS.
+4. For every failing check, give a concrete, copy-pasteable fix (the exact line to add, the section to cut, the file:line pointer to substitute for an embedded block) — not vague advice.
+
+## Output format
+
+Your first response line MUST be exactly:
+
+```
+## CLAUDE.md evaluation
+```
+
+Then:
+
+```
+**File**: <path>
+**Lines**: <count>
+**Verdict**: PASS | NOT-PASS
+
+### Critical
+- [PASS|FAIL] C<n>: <check> — <evidence: quoted line or described absence>
+...
+
+### Important
+- [PASS|FAIL] I<n>: <check> — <evidence>
+...
+
+### Polish (only if requested)
+- [INFO] P<n>: <check> — <suggestion>
+...
+
+### Failing items and fixes
+- C<n>/I<n>: <specific, concrete fix the orchestrator should apply>
+...
+
+### Reasoning
+<2-3 sentences applying the verdict logic: which tier(s) failed and why the verdict follows.>
+```
+
+If the verdict is PASS, still list the per-check results and note any Polish-tier opportunities; omit the "Failing items and fixes" section when there are none.
+
+## Discipline
+
+- Binary judgments only — each check is PASS or FAIL, no partial credit.
+- Ground every FAIL in evidence; never assert a failure you cannot point to.
+- Do not soften the verdict to be agreeable; a clean-room second opinion is only useful if it is honest.
+- Stay inside this single response. You are one evaluation pass, not a conversation.

--- a/plugins/review-claude-md/copilot-skills/review-claude-md/SKILL.md
+++ b/plugins/review-claude-md/copilot-skills/review-claude-md/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: review-claude-md
+description: >-
+  Audit and fix a CLAUDE.md against a structured tiered checklist from a normal
+  Copilot session when the user asks to review, score, audit, or improve a
+  CLAUDE.md. Scans the target repo, runs the bundled validation scripts, reports a
+  PASS / NEEDS WORK / FAIL verdict with evidence, then fixes failing checks and
+  re-evaluates against the rubric. Not for generic markdown cleanup, and not for
+  reviewing Copilot or Codex skills/agents.
+allowed-tools:
+  - agent
+  - read
+  - shell
+---
+
+# Review CLAUDE.md (Copilot)
+
+Evaluate any CLAUDE.md against a tiered binary checklist (Critical / Important / Polish), produce a categorical verdict (PASS / NEEDS WORK / FAIL), then fix the failing checks and re-evaluate until it passes. The current session agent is the orchestrator and runs the whole workflow.
+
+## Orchestration rule (read first)
+
+**Run the steps inline in the main session by default - they are sequential and share context, so inline is simpler and more reliable than fan-out. Only delegate the re-evaluation to the claude-md-evaluator agent when a clean-room second opinion helps; do not fan out one agent per step.**
+
+The source Claude workflow spawned helper agents (an Explore agent to scan the repo, a general-purpose agent to run the scripts, and a re-evaluation agent) but it ran them strictly sequentially and they shared the same context. On Copilot there is nothing to gain from re-spawning that chain as separate agents: do the scan, the scripts, the report, the fixes, and the re-check yourself in one session. The only sanctioned delegation is the optional `claude-md-evaluator` agent (bundled under `agents/`, invoked via the `agent` tool) for an independent post-fix verdict.
+
+## Arguments
+
+Parse from the user's request:
+
+- First path-like token: the target repo root (default: current working directory).
+- `--score-only` — report the verdict without applying fixes.
+- `--fix` — fix all failing checks (this is the default behavior).
+- `--verbose` — show the reasoning for each check.
+- `--thorough` — also evaluate and report the Polish tier.
+
+If no CLAUDE.md is resolvable under the target, say so and ask which repo/file to review - do not invent one.
+
+## Verdict logic
+
+Read [references/rubric.md](references/rubric.md) for the full tiered checklist (Critical, Important, Polish) and the verdict thresholds. Summary: any Critical fail → **FAIL**; 3+ Important fails → **NEEDS WORK**; otherwise **PASS**.
+
+## Workflow
+
+### Phase 1 - Discovery (inline)
+
+1. Identify the target repo root (from the argument or cwd).
+2. Find all CLAUDE.md files: root, `.claude/CLAUDE.md`, `CLAUDE.local.md`, subdirectory CLAUDE.md files.
+3. Find `.claude/rules/*.md` files.
+4. Note git-tracked vs gitignored status.
+
+### Phase 2 - Codebase context (inline)
+
+Scan the target repo yourself with `read` and `shell` (grep/find). Gather a compact summary - do not re-read these files again later:
+
+- Build system + commands (Makefile, package.json scripts, Cargo.toml, go.mod, pyproject.toml).
+- Test framework + test commands (jest/vitest/pytest configs, etc.).
+- Lint/format tool + commands (.eslintrc, biome.json, .prettierrc, rustfmt.toml, golangci config).
+- CI provider + workflow names (`.github/workflows/`, `.gitlab-ci.yml`).
+- Existing `.claude/rules/` files and their topics.
+- Commit message convention (`git log --oneline -20`).
+- README sections that overlap with CLAUDE.md content.
+
+### Phase 3 - Automated checks (inline, via `shell`)
+
+Run both bundled validation scripts via the `shell` tool against the target repo root and parse the JSON (`{check, pass, detail}`, one object per line):
+
+```bash
+scripts/validate-claudemd.sh "<repo-root>"
+scripts/validate-commands.sh "<repo-root>"
+```
+
+(Resolve `scripts/` relative to this skill directory.) Each `pass: false` maps to the corresponding checklist criterion. Use these results directly in Phase 5; do not re-run them.
+
+### Phase 4 - Manual evaluation (inline)
+
+Re-read [references/rubric.md](references/rubric.md) in full before this phase to avoid drifting from the criteria. For each criterion not already settled by the scripts, judge binary pass/fail:
+
+1. Read the check description and its source reference.
+2. Examine the relevant section of the CLAUDE.md.
+3. Record the result with specific evidence (quote the line, or describe the absence).
+4. If `--verbose`, show the reasoning per check.
+5. If `--thorough`, also evaluate the Polish tier.
+
+Read [references/sources.md](references/sources.md) for authoritative source URLs when citing findings.
+
+### Phase 5 - Synthesize verdict (inline)
+
+Think step by step before declaring:
+
+1. List all Critical results - any FAIL?
+2. Count Important FAILs - 3 or more?
+3. Apply the verdict logic.
+4. Write 2-3 sentences explaining the reasoning.
+
+### Phase 6 - Report findings before fixes
+
+Read [references/output-format.md](references/output-format.md) and emit the verdict using that template, scored against [references/rubric.md](references/rubric.md). **Report findings before applying any fixes**, unless the user explicitly asked for immediate remediation - then go straight to Phase 7 and report after.
+
+### Phase 7 - Fix (unless `--score-only`)
+
+In `--fix` mode (the default):
+
+1. Address every failing Critical and Important check.
+2. Re-read [references/sources.md](references/sources.md) for rewriting principles first - fixes that violate the source guidelines just create new failures.
+3. Create `.claude/rules/*.md` files if the root file exceeds 150 lines.
+4. Target: under 150 lines (ideally 50-100 for the root).
+
+Editing is a side effect the user opted into by asking to fix/improve their CLAUDE.md; in `--score-only` mode, do not modify any files.
+
+### Phase 8 - Re-evaluate and iterate
+
+After fixing, re-evaluate the file against the rubric. Two paths:
+
+- **Inline (default):** re-run both validation scripts, re-check the manual criteria, re-apply the verdict logic, and produce a post-fix report per [references/output-format.md](references/output-format.md).
+- **Delegated (optional):** when a clean-room second opinion is worthwhile (e.g. a borderline verdict, or the user wants an independent check), invoke the `claude-md-evaluator` agent via the `agent` tool. Pass it: the fixed CLAUDE.md path, the rubric (and `references/rubric.md` path), the latest validation-script output, the Phase 2 codebase summary, and the repo root. It returns a PASS / NOT-PASS report with failing items and concrete fixes; its first line is `## CLAUDE.md evaluation`.
+
+If the result is not PASS, apply the remaining fixes inline and re-evaluate again. Iterate until PASS or no further high-value fixes remain; if you stop short of PASS, say which checks remain and why they were left.
+
+## Good vs bad examples
+
+Read [references/examples.md](references/examples.md) for good-vs-bad pairs covering commands, architecture, gotchas, and format sections.
+
+## Scope
+
+This skill audits CLAUDE.md operational-context files. It is not for generic markdown cleanup, prose editing, or reviewing Copilot/Codex skills and agents. For those, use a different tool.

--- a/plugins/review-claude-md/copilot-skills/review-claude-md/references/examples.md
+++ b/plugins/review-claude-md/copilot-skills/review-claude-md/references/examples.md
@@ -1,0 +1,128 @@
+# Good vs Bad Examples
+
+## Contents
+
+- [Commands](#commands)
+- [Architecture](#architecture)
+- [Gotchas](#gotchas)
+- [Format](#format)
+
+---
+
+## Commands
+
+### Good
+
+```markdown
+## Commands
+- Build: `npm run build`
+- Test (full suite): `npm test`
+- Test (focused): `npm test -- --testPathPattern="auth"`
+- Lint: `npm run lint`
+- Pre-commit: `npm run lint && npm test`
+```
+
+Specific, correct, includes a focused-test variant and pre-commit workflow.
+
+### Bad
+
+```markdown
+## Commands
+- Run tests
+- Build the project
+```
+
+Missing actual commands, no focused-test option, no lint or pre-commit step.
+
+---
+
+## Architecture
+
+### Good
+
+```markdown
+## Architecture
+- `src/api/` — Express route handlers; each file exports a router mounted in `src/api/index.ts:12`
+- `src/services/` — Business logic called by API handlers; never import from `src/api/`
+- `src/db/` — Knex query builders; all migrations in `src/db/migrations/`
+- Data flow: Request → route handler → service → db query → response
+- The `src/services/billing.ts:34` webhook handler is the only entry point for Stripe events
+```
+
+Explains relationships, enforces boundaries, uses file:line pointers.
+
+### Bad
+
+```markdown
+## Architecture
+src/
+  api/
+  services/
+  db/
+  utils/
+```
+
+A file tree with no explanation of how components relate or what rules govern them.
+
+---
+
+## Gotchas
+
+### Good
+
+```markdown
+## Gotchas
+- The payment service uses eventual consistency — always check `transaction.status` before assuming completion (see `services/payment.ts:45`)
+- Tests that touch the `orders` table must call `resetOrderSequence()` in `afterEach` or subsequent tests get duplicate key errors (see `test/helpers.ts:12`)
+```
+
+Project-specific, actionable, points to exact code locations.
+
+### Bad
+
+```markdown
+## Gotchas
+- Handle errors gracefully
+- Make sure tests pass before committing
+- Don't forget to update documentation
+```
+
+Generic advice that applies to any project. Claude already knows this.
+
+---
+
+## Format
+
+### Good
+
+```markdown
+## Style
+- Use `snake_case` for DB column names (differs from JS `camelCase` convention)
+- Error responses must include `error_code` field — see `src/errors.ts:8` for registry
+- Import order enforced by ESLint — see `.eslintrc.js` (do not duplicate rules here)
+```
+
+Concise bullets, only project-specific deviations, pointers to config files.
+
+### Bad
+
+```markdown
+## Style
+
+We use TypeScript in this project. TypeScript is a typed superset of JavaScript
+that compiles to plain JavaScript. All files should use the `.ts` extension.
+When writing functions, make sure to add proper type annotations to all parameters
+and return values. Here is an example of how we write functions:
+
+export function calculateTotal(items: CartItem[]): number {
+  return items.reduce((sum, item) => {
+    const price = item.price * item.quantity;
+    const discount = item.discount ?? 0;
+    return sum + (price - discount);
+  }, 0);
+}
+
+Always follow this pattern when writing new functions.
+```
+
+Long paragraph, embedded code block, tells Claude things it already knows about TypeScript.

--- a/plugins/review-claude-md/copilot-skills/review-claude-md/references/output-format.md
+++ b/plugins/review-claude-md/copilot-skills/review-claude-md/references/output-format.md
@@ -1,0 +1,50 @@
+# Output Format Templates
+
+## Initial Report
+
+```
+## CLAUDE.md Review
+
+**File**: <path>
+**Lines**: <count>
+**Verdict**: PASS | NEEDS WORK | FAIL
+
+### Critical
+- [PASS] C1: Build/test/lint commands present and correct
+- [FAIL] C2: 247 lines exceeds 150 limit
+...
+
+### Important
+- [PASS] I1: Architecture describes component relationships
+- [FAIL] I3: No project-specific gotchas found
+...
+
+### Polish (--thorough only)
+- [INFO] P1: No focused-test command documented
+...
+
+### Chain of Thought
+<reasoning explaining how each check was evaluated and how the verdict was determined>
+
+### Verdict: <VERDICT>
+<summary — e.g., "4 Important checks failed (threshold: 3)" or "All Critical passed, 1 Important failed">
+```
+
+## Post-Fix Report
+
+```
+## Post-Fix Review
+
+**File**: <path>
+**Lines**: <count> (was: <old_count>)
+**Verdict**: PASS
+
+### Changes Made
+- <change 1>
+- <change 2>
+...
+
+### Rules Files Created
+- [.claude/rules/<name>.md](.claude/rules/<name>.md) — <purpose>
+...
+```

--- a/plugins/review-claude-md/copilot-skills/review-claude-md/references/rubric.md
+++ b/plugins/review-claude-md/copilot-skills/review-claude-md/references/rubric.md
@@ -1,0 +1,69 @@
+# Review Rubric — Tiered Binary Checklist
+
+## Contents
+
+- [Critical Checks](#critical-checks)
+- [Important Checks](#important-checks)
+- [Polish Checks](#polish-checks)
+- [Verdict Logic](#verdict-logic)
+
+---
+
+## Critical Checks
+
+**Rule: Must pass ALL — any single fail = FAIL verdict.**
+
+| ID  | Check                                                             | Source                                  |
+|:----|:------------------------------------------------------------------|:----------------------------------------|
+| C1  | Build, test, and lint commands present and correct                | Builder.io, Official Best Practices     |
+| C2  | Root CLAUDE.md under 150 lines                                    | HumanLayer, Community Meta-analysis     |
+| C3  | No generic advice Claude already knows (e.g., "write clean code") | Official Best Practices                 |
+| C4  | No README content duplication                                     | Official Best Practices, Anthropic Blog |
+
+**How to evaluate:** Run each command listed to verify correctness. Count lines with `wc -l`. For C3 and C4, read every line and ask: "Would Claude behave differently without this?" If not, it fails C3. Compare against README section by section for C4.
+
+---
+
+## Important Checks
+
+**Rule: 3 or more fails = NEEDS WORK verdict.**
+
+| ID  | Check                                                            | Source                            |
+|:----|:-----------------------------------------------------------------|:----------------------------------|
+| I1  | Architecture describes component relationships (not just a tree) | HumanLayer                        |
+| I2  | Domain terminology mapped to code concepts                       | HumanLayer                        |
+| I3  | At least 2 project-specific, non-obvious gotchas                 | Arize                             |
+| I4  | Test framework and conventions documented                        | Builder.io                        |
+| I5  | Pre-commit workflow documented                                   | Builder.io                        |
+| I6  | Bullets over paragraphs throughout                               | Official Best Practices, Maxitect |
+| I7  | Pointers over copies (file:line refs, not embedded code blocks)  | HumanLayer                        |
+| I8  | Style rules only where they differ from language defaults        | Official Best Practices           |
+| I9  | Modularized with [.claude/rules/](.claude/rules/) if root file is complex | Official Memory Docs       |
+
+**How to evaluate:** For I1, check that the architecture section explains how components interact, not just where files live. For I3, gotchas must be specific to this project — "always run migrations before tests" qualifies, "handle errors gracefully" does not. For I7, flag any embedded code block over 5 lines that could be replaced with a file reference.
+
+---
+
+## Polish Checks
+
+**Rule: Informational only. Reported when `--thorough` is passed. Do not affect verdict.**
+
+| ID  | Check                                                             | Source             |
+|:----|:------------------------------------------------------------------|:-------------------|
+| P1  | Single-test / focused-test command available                      | Builder.io         |
+| P2  | Mock strategy documented (hand-written vs generated, location)    | Community practice |
+| P3  | Integration test requirements documented (Docker, env vars, etc.) | Community practice |
+| P4  | Cross-system dependencies documented (IPC contracts, schemas)     | Community practice |
+| P5  | Commit message format with examples                               | Community practice |
+
+**How to evaluate:** These are quality-of-life improvements. Report each as `[INFO]` with a concrete suggestion. Do not let polish items influence the overall verdict.
+
+---
+
+## Verdict Logic
+
+| Condition                                      | Verdict        |
+|:-----------------------------------------------|:---------------|
+| Any Critical check fails                       | **FAIL**       |
+| 3+ Important checks fail                       | **NEEDS WORK** |
+| All Critical pass, fewer than 3 Important fail | **PASS**       |

--- a/plugins/review-claude-md/copilot-skills/review-claude-md/references/sources.md
+++ b/plugins/review-claude-md/copilot-skills/review-claude-md/references/sources.md
@@ -1,0 +1,39 @@
+# Authoritative References & Key Principles
+
+## Contents
+- Authoritative References
+- Key Principles
+
+---
+
+## Authoritative References
+
+When citing deductions, use these sources. Last verified: 2026-03-09. Re-verify URLs quarterly or when a link fails.
+
+- **Official Best Practices**: https://code.claude.com/docs/en/best-practices
+- **Official Memory Docs**: https://code.claude.com/docs/en/memory
+- **Anthropic Blog**: https://claude.com/blog/using-claude-md-files
+- **Anthropic Internal PDF**: https://www-cdn.anthropic.com/58284b19e702b49db9302d5b6f135ad8871e7658.pdf
+- **Builder.io**: https://www.builder.io/blog/claude-md-guide
+- **HumanLayer**: https://www.humanlayer.dev/blog/writing-a-good-claude-md
+- **Arize**: https://arize.com/blog/claude-md-best-practices-learned-from-optimizing-claude-code-with-prompt-learning/
+- **Maxitect**: https://www.maxitect.blog/posts/maximising-claude-code-building-an-effective-claudemd
+- **Dometrain**: https://dometrain.com/blog/creating-the-perfect-claudemd-for-claude-code/
+- **Grinsztajn et al. (2025)**: https://arxiv.org/abs/2602.11988 — empirical study on AGENTS.md/CLAUDE.md effectiveness; key finding: developer-written files with minimal, tooling-specific requirements outperform verbose/overview-heavy files; directory enumeration provides no measurable navigation benefit; redundancy with README reduces effectiveness
+
+---
+
+## Key Principles
+
+These principles guide both scoring and fixing:
+
+- **Brevity is #1**: "Bloated CLAUDE.md files cause Claude to ignore your actual instructions" (Official)
+- **~150 instruction limit**: "Frontier LLMs can follow approximately 150-200 instructions consistently. Claude Code's system prompt already contains ~50." (HumanLayer)
+- **Commands are highest-value**: Exact build/test/lint commands Claude cannot guess (Builder.io)
+- **Pointers over copies**: Use `file:line` references, not embedded code snippets (HumanLayer)
+- **Alternatives, not negatives**: "Use Y instead of X" not "Never use X" (Arize)
+- **No README duplication**: CLAUDE.md is for AI-operational context, not human onboarding (Official)
+- **Modularize with rules/**: Use [.claude/rules/](.claude/rules/) for detailed topic files, keep root CLAUDE.md lean (Official)
+- **Use hooks for deterministic actions**: "Unlike CLAUDE.md instructions which are advisory, hooks are deterministic" (Official)
+- **The "First 5 Minutes" Test**: Could a new dev build, test, and contribute reading only this file? (Community)
+- **Treat it like code**: Review when things go wrong, prune regularly (Official)

--- a/plugins/review-claude-md/copilot-skills/review-claude-md/scripts/validate-claudemd.sh
+++ b/plugins/review-claude-md/copilot-skills/review-claude-md/scripts/validate-claudemd.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# validate-claudemd.sh — Validate CLAUDE.md structure and content quality.
+#
+# Usage:
+#   ./validate-claudemd.sh <repo-root>
+#
+# Arguments:
+#   repo-root — Path to the repository root containing CLAUDE.md
+#
+# Output: One JSON object per line with {check, pass, detail}.
+#
+# Dependencies: bash 4+, grep, sed, awk
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <repo-root>" >&2
+  exit 1
+fi
+
+REPO_ROOT="$1"
+CLAUDE_MD="${REPO_ROOT}/CLAUDE.md"
+
+# Escape a string for safe embedding in a JSON string value.
+# Handles: \ -> \\, " -> \", newline -> \n, tab -> \t, CR -> \r
+json_escape() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  s="${s//$'\n'/\\n}"
+  s="${s//$'\t'/\\t}"
+  s="${s//$'\r'/\\r}"
+  printf '%s' "$s"
+}
+
+if [[ ! -f "$CLAUDE_MD" ]]; then
+  echo "{\"check\": \"file-exists\", \"pass\": false, \"detail\": \"CLAUDE.md not found in $(json_escape "${REPO_ROOT}")\"}"
+  exit 0
+fi
+
+CONTENT=$(cat "$CLAUDE_MD")
+
+# --- Check: line-count ---
+LINE_COUNT=$(wc -l < "$CLAUDE_MD" | tr -d ' ')
+if [[ "$LINE_COUNT" -le 150 ]]; then
+  echo "{\"check\": \"line-count\", \"pass\": true, \"detail\": \"${LINE_COUNT} lines, under 150 limit\"}"
+else
+  echo "{\"check\": \"line-count\", \"pass\": false, \"detail\": \"${LINE_COUNT} lines, exceeds 150 limit\"}"
+fi
+
+# --- Check: readme-duplication ---
+README_MD="${REPO_ROOT}/README.md"
+if [[ -f "$README_MD" ]]; then
+  # Extract first 5 non-empty lines from each file
+  CLAUDE_LINES=$(grep -v '^[[:space:]]*$' "$CLAUDE_MD" | head -5)
+  README_LINES=$(grep -v '^[[:space:]]*$' "$README_MD" | head -5)
+
+  SHARED=0
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    if echo "$README_LINES" | grep -qF "$line"; then
+      SHARED=$((SHARED + 1))
+    fi
+  done <<< "$CLAUDE_LINES"
+
+  if [[ "$SHARED" -ge 3 ]]; then  # 3/5 shared lines = likely copy-paste from README
+    echo "{\"check\": \"readme-duplication\", \"pass\": false, \"detail\": \"${SHARED}/5 leading lines overlap with README.md — likely duplication\"}"
+  else
+    echo "{\"check\": \"readme-duplication\", \"pass\": true, \"detail\": \"${SHARED}/5 leading lines shared with README.md\"}"
+  fi
+else
+  echo "{\"check\": \"readme-duplication\", \"pass\": true, \"detail\": \"No README.md found, skipping duplication check\"}"
+fi
+
+# --- Check: generic-advice ---
+GENERIC_PATTERNS=(
+  "write clean code"
+  "handle errors gracefully"
+  "follow best practices"
+  "always add tests"
+  "keep code DRY"
+  "use meaningful names"
+)
+
+GENERIC_FOUND=0
+for pattern in ${GENERIC_PATTERNS[@]+"${GENERIC_PATTERNS[@]}"}; do
+  MATCH=$(grep -inF "$pattern" "$CLAUDE_MD" || true)
+  if [[ -n "$MATCH" ]]; then
+    LINE_NUM=$(echo "$MATCH" | head -1 | cut -d: -f1)
+    LINE_TEXT=$(echo "$MATCH" | head -1 | cut -d: -f2- | sed 's/^[[:space:]]*//' | cut -c1-80)
+    echo "{\"check\": \"generic-advice\", \"pass\": false, \"detail\": \"Found: '$(json_escape "${pattern}")' on line ${LINE_NUM}: $(json_escape "${LINE_TEXT}")\"}"
+    GENERIC_FOUND=$((GENERIC_FOUND + 1))
+  fi
+done
+if [[ "$GENERIC_FOUND" -eq 0 ]]; then
+  echo "{\"check\": \"generic-advice\", \"pass\": true, \"detail\": \"No generic advice patterns found\"}"
+fi
+
+# --- Check: long-code-blocks ---
+LONG_BLOCKS=0
+IN_BLOCK=0
+BLOCK_LINES=0
+BLOCK_START=0
+LINE_NUM=0
+while IFS= read -r line; do
+  LINE_NUM=$((LINE_NUM + 1))
+  if [[ "$line" =~ ^\`\`\` ]]; then
+    if [[ "$IN_BLOCK" -eq 0 ]]; then
+      IN_BLOCK=1
+      BLOCK_LINES=0
+      BLOCK_START=$LINE_NUM
+    else
+      IN_BLOCK=0
+      if [[ "$BLOCK_LINES" -gt 10 ]]; then  # >10 lines = should be a file:line ref instead
+        echo "{\"check\": \"long-code-blocks\", \"pass\": false, \"detail\": \"Code block starting at line ${BLOCK_START} is ${BLOCK_LINES} lines (>10)\"}"
+        LONG_BLOCKS=$((LONG_BLOCKS + 1))
+      fi
+    fi
+  elif [[ "$IN_BLOCK" -eq 1 ]]; then
+    BLOCK_LINES=$((BLOCK_LINES + 1))
+  fi
+done <<< "$CONTENT"
+if [[ "$LONG_BLOCKS" -eq 0 ]]; then
+  echo "{\"check\": \"long-code-blocks\", \"pass\": true, \"detail\": \"No code blocks exceed 10 lines\"}"
+fi
+
+# --- Check: bullets-vs-paragraphs ---
+BULLET_LINES=0
+PARA_LINES=0
+CONSEC_PLAIN=0
+BVP_IN_BLOCK=0
+while IFS= read -r line; do
+  # Track fenced code blocks and skip their contents
+  if [[ "$line" =~ ^\`\`\` ]]; then
+    if [[ "$BVP_IN_BLOCK" -eq 0 ]]; then
+      BVP_IN_BLOCK=1
+    else
+      BVP_IN_BLOCK=0
+    fi
+    # 3+ consecutive plain lines = paragraph block (vs bullet list)
+    if [[ "$CONSEC_PLAIN" -ge 3 ]]; then
+      PARA_LINES=$((PARA_LINES + CONSEC_PLAIN))
+    fi
+    CONSEC_PLAIN=0
+    continue
+  fi
+  if [[ "$BVP_IN_BLOCK" -eq 1 ]]; then
+    continue
+  fi
+  # Skip blank lines, headings
+  if [[ "$line" =~ ^[[:space:]]*$ ]] || [[ "$line" =~ ^#+\  ]]; then
+    if [[ "$CONSEC_PLAIN" -ge 3 ]]; then
+      PARA_LINES=$((PARA_LINES + CONSEC_PLAIN))
+    fi
+    CONSEC_PLAIN=0
+    continue
+  fi
+  # Bullet lines: starts with - or * or numbered list
+  if [[ "$line" =~ ^[[:space:]]*[-*] ]] || [[ "$line" =~ ^[[:space:]]*[0-9]+\. ]]; then
+    if [[ "$CONSEC_PLAIN" -ge 3 ]]; then
+      PARA_LINES=$((PARA_LINES + CONSEC_PLAIN))
+    fi
+    CONSEC_PLAIN=0
+    BULLET_LINES=$((BULLET_LINES + 1))
+  else
+    CONSEC_PLAIN=$((CONSEC_PLAIN + 1))
+  fi
+done <<< "$CONTENT"
+# Flush remaining
+if [[ "$CONSEC_PLAIN" -ge 3 ]]; then
+  PARA_LINES=$((PARA_LINES + CONSEC_PLAIN))
+fi
+
+TOTAL=$((BULLET_LINES + PARA_LINES))
+if [[ "$TOTAL" -eq 0 ]]; then
+  echo "{\"check\": \"bullets-vs-paragraphs\", \"pass\": true, \"detail\": \"No bullet or paragraph content detected\"}"
+else
+  RATIO=$((BULLET_LINES * 100 / TOTAL))
+  if [[ "$RATIO" -gt 60 ]]; then  # >60% bullets = good structure per Anthropic best practices
+    echo "{\"check\": \"bullets-vs-paragraphs\", \"pass\": true, \"detail\": \"Bullet ratio ${RATIO}% (${BULLET_LINES} bullet lines, ${PARA_LINES} paragraph lines)\"}"
+  else
+    echo "{\"check\": \"bullets-vs-paragraphs\", \"pass\": false, \"detail\": \"Bullet ratio ${RATIO}% (${BULLET_LINES} bullet lines, ${PARA_LINES} paragraph lines) — prefer >60%\"}"
+  fi
+fi
+
+# --- Check: modularization ---
+if [[ "$LINE_COUNT" -gt 150 ]]; then
+  if [[ -d "${REPO_ROOT}/.claude/rules" ]]; then
+    echo "{\"check\": \"modularization\", \"pass\": true, \"detail\": \"CLAUDE.md is ${LINE_COUNT} lines but .claude/rules/ exists for modular rules\"}"
+  else
+    echo "{\"check\": \"modularization\", \"pass\": false, \"detail\": \"CLAUDE.md is ${LINE_COUNT} lines with no .claude/rules/ directory — consider splitting into modular rules\"}"
+  fi
+else
+  echo "{\"check\": \"modularization\", \"pass\": true, \"detail\": \"CLAUDE.md is ${LINE_COUNT} lines, under modularization threshold\"}"
+fi

--- a/plugins/review-claude-md/copilot-skills/review-claude-md/scripts/validate-commands.sh
+++ b/plugins/review-claude-md/copilot-skills/review-claude-md/scripts/validate-commands.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# validate-commands.sh — Validate commands section in CLAUDE.md.
+#
+# Usage:
+#   ./validate-commands.sh <repo-root>
+#
+# Arguments:
+#   repo-root — Path to the repository root containing CLAUDE.md
+#
+# Output: One JSON object per line with {check, pass, detail}.
+#
+# Dependencies: bash 4+, grep
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <repo-root>" >&2
+  exit 1
+fi
+
+REPO_ROOT="$1"
+CLAUDE_MD="${REPO_ROOT}/CLAUDE.md"
+
+json_escape() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  s="${s//$'\n'/\\n}"
+  s="${s//$'\t'/\\t}"
+  s="${s//$'\r'/\\r}"
+  echo "$s"
+}
+
+if [[ ! -f "$CLAUDE_MD" ]]; then
+  echo "{\"check\": \"file-exists\", \"pass\": false, \"detail\": \"CLAUDE.md not found in $(json_escape "${REPO_ROOT}")\"}"
+  exit 0
+fi
+
+# --- Check: has-build ---
+BUILD_MATCH=$(grep -inE "npm run build|cargo build|go build|mvn |gradle |bazel build" "$CLAUDE_MD" | head -1 || true)
+if [[ -z "$BUILD_MATCH" ]]; then
+  BUILD_MATCH=$(grep -nE '(^|[|;&`])\s*make\b' "$CLAUDE_MD" | head -1 || true)
+fi
+if [[ -n "$BUILD_MATCH" ]]; then
+  LINE_NUM=$(echo "$BUILD_MATCH" | cut -d: -f1)
+  echo "{\"check\": \"has-build\", \"pass\": true, \"detail\": \"Build command found on line ${LINE_NUM}\"}"
+else
+  echo "{\"check\": \"has-build\", \"pass\": false, \"detail\": \"No build command found (looked for make, npm run build, cargo build, go build, mvn, gradle)\"}"
+fi
+
+# --- Check: has-test ---
+TEST_MATCH=$(grep -inE "npm test|pytest|cargo test|go test|jest|vitest|make test|yarn test|bun test" "$CLAUDE_MD" | head -1 || true)
+if [[ -n "$TEST_MATCH" ]]; then
+  LINE_NUM=$(echo "$TEST_MATCH" | cut -d: -f1)
+  echo "{\"check\": \"has-test\", \"pass\": true, \"detail\": \"Test command found on line ${LINE_NUM}\"}"
+else
+  echo "{\"check\": \"has-test\", \"pass\": false, \"detail\": \"No test command found (looked for npm test, pytest, cargo test, go test, jest, vitest)\"}"
+fi
+
+# --- Check: has-lint ---
+LINT_MATCH=$(grep -inE "eslint|biome|ruff|golangci-lint|clippy|prettier|make lint|yarn lint|npm run lint" "$CLAUDE_MD" | head -1 || true)
+if [[ -n "$LINT_MATCH" ]]; then
+  LINE_NUM=$(echo "$LINT_MATCH" | cut -d: -f1)
+  echo "{\"check\": \"has-lint\", \"pass\": true, \"detail\": \"Lint command found on line ${LINE_NUM}\"}"
+else
+  echo "{\"check\": \"has-lint\", \"pass\": false, \"detail\": \"No lint command found (looked for eslint, biome, ruff, golangci-lint, clippy, prettier)\"}"
+fi
+
+# --- Check: has-precommit ---
+PRECOMMIT_MATCH=$(grep -inE "pre-commit|precommit|before commit|commit checklist|before pushing|pre commit" "$CLAUDE_MD" | head -1 || true)
+if [[ -n "$PRECOMMIT_MATCH" ]]; then
+  LINE_NUM=$(echo "$PRECOMMIT_MATCH" | cut -d: -f1)
+  echo "{\"check\": \"has-precommit\", \"pass\": true, \"detail\": \"Pre-commit workflow found on line ${LINE_NUM}\"}"
+else
+  echo "{\"check\": \"has-precommit\", \"pass\": false, \"detail\": \"No pre-commit workflow or checklist found\"}"
+fi
+
+# --- Check: commands-valid ---
+INVALID_COUNT=0
+VALID_COUNT=0
+
+# Check npm/yarn/bun commands → package.json
+if grep -qiE "npm |yarn |bun " "$CLAUDE_MD"; then
+  if [[ -f "${REPO_ROOT}/package.json" ]]; then
+    VALID_COUNT=$((VALID_COUNT + 1))
+  else
+    echo "{\"check\": \"commands-valid\", \"pass\": false, \"detail\": \"npm/yarn/bun commands referenced but no package.json found\"}"
+    INVALID_COUNT=$((INVALID_COUNT + 1))
+  fi
+fi
+
+# Check make commands → Makefile
+# Anchor to command context: start of line, after pipe/semicolon/backtick, or "make target" pattern
+if grep -qE '(^|[|;&`])\s*make\b' "$CLAUDE_MD"; then
+  if [[ -f "${REPO_ROOT}/Makefile" ]] || [[ -f "${REPO_ROOT}/makefile" ]] || [[ -f "${REPO_ROOT}/GNUmakefile" ]]; then
+    VALID_COUNT=$((VALID_COUNT + 1))
+  else
+    echo "{\"check\": \"commands-valid\", \"pass\": false, \"detail\": \"make commands referenced but no Makefile found\"}"
+    INVALID_COUNT=$((INVALID_COUNT + 1))
+  fi
+fi
+
+# Check cargo commands → Cargo.toml
+if grep -qiE "cargo " "$CLAUDE_MD"; then
+  if [[ -f "${REPO_ROOT}/Cargo.toml" ]]; then
+    VALID_COUNT=$((VALID_COUNT + 1))
+  else
+    echo "{\"check\": \"commands-valid\", \"pass\": false, \"detail\": \"cargo commands referenced but no Cargo.toml found\"}"
+    INVALID_COUNT=$((INVALID_COUNT + 1))
+  fi
+fi
+
+# Check go commands → go.mod
+if grep -qiE "go build|go test" "$CLAUDE_MD"; then
+  if [[ -f "${REPO_ROOT}/go.mod" ]]; then
+    VALID_COUNT=$((VALID_COUNT + 1))
+  else
+    echo "{\"check\": \"commands-valid\", \"pass\": false, \"detail\": \"go commands referenced but no go.mod found\"}"
+    INVALID_COUNT=$((INVALID_COUNT + 1))
+  fi
+fi
+
+# Check pytest → python project indicators
+if grep -qiE "pytest" "$CLAUDE_MD"; then
+  if [[ -f "${REPO_ROOT}/pyproject.toml" ]] || [[ -f "${REPO_ROOT}/setup.py" ]] || [[ -f "${REPO_ROOT}/setup.cfg" ]]; then
+    VALID_COUNT=$((VALID_COUNT + 1))
+  else
+    echo "{\"check\": \"commands-valid\", \"pass\": false, \"detail\": \"pytest referenced but no Python project file found (pyproject.toml, setup.py)\"}"
+    INVALID_COUNT=$((INVALID_COUNT + 1))
+  fi
+fi
+
+if [[ "$INVALID_COUNT" -eq 0 ]]; then
+  if [[ "$VALID_COUNT" -gt 0 ]]; then
+    echo "{\"check\": \"commands-valid\", \"pass\": true, \"detail\": \"${VALID_COUNT} command tool(s) verified against repo files\"}"
+  else
+    echo "{\"check\": \"commands-valid\", \"pass\": true, \"detail\": \"No tool-specific commands to validate\"}"
+  fi
+fi

--- a/plugins/review-claude-md/plugin.json
+++ b/plugins/review-claude-md/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "review-claude-md",
+  "description": "Audit a CLAUDE.md file against a structured rubric from a normal Copilot session. Keeps orchestration in-session: scans the repo, runs the bundled validation scripts, reports findings, applies fixes on request, then re-evaluates against the rubric (optionally via a native evaluator agent). Runs every step in-session by default for reliable execution.",
+  "version": "0.1.0",
+  "author": { "name": "Smykla Skalski Labs" },
+  "homepage": "https://github.com/smykla-skalski/sai",
+  "repository": "https://github.com/smykla-skalski/sai",
+  "license": "MIT",
+  "keywords": ["copilot", "custom-agents", "claude-md", "audit", "documentation", "linting"],
+  "category": "Developer Tools",
+  "agents": "agents/",
+  "skills": "copilot-skills/"
+}

--- a/plugins/staff-code-review/agents/architecture-design-reviewer.agent.md
+++ b/plugins/staff-code-review/agents/architecture-design-reviewer.agent.md
@@ -1,0 +1,44 @@
+---
+name: architecture-design-reviewer
+description: Staff-code-review dimension reviewer for $staff-code-review. Spawn only inside a staff-code-review workflow.
+model: gpt-5.4-mini
+model_reasoning_effort: high
+tools: Read
+user-invocable: true
+---
+
+You are the **Architecture & Design** reviewer in a staff-level code review. You do not ask "does this code work?" — you ask "should this code exist, does it fit the system, and what does it cost us in 18 months?" Read the diff and the Research Brief you were handed, then judge the change as a pattern other engineers will copy, an API surface that is hard to take back, and a data model that has to evolve.
+
+## Lens checklist
+
+- **Architectural alignment.** Does this introduce a pattern that will be copied? Is it a pattern worth copying? Does it violate an ADR or an established convention? Is it solving the right problem, or optimizing the wrong layer? Does it fork where a shared solution already exists? Would it survive 10x growth in users/data/services?
+- **API design.** Deprecation path for anything public. Error-contract stability (consumers will depend on codes, messages, shapes — Hyrum's Law). Surface-area minimization — does the API leak implementation details that constrain future change? Expand-and-contract for breaking changes (add new → migrate → remove old).
+- **Data model evolution.** Impact on existing records. Unbounded growth (no pagination, TTL, or archival). Painful joins at scale. Intentional denormalization documented. What happens to existing data when this deploys?
+- **Cross-team impact.** Which teams consume the affected APIs/events — were they notified? Does this create a dependency another team absorbs or on-call burden they didn't sign up for? Paved-road / golden-path drift. Competing patterns for one problem signal a missing ADR.
+
+**Use the Research Brief:** check "Existing Patterns" for convention violations; use "Callers & Consumers" caller counts to size cross-team blast radius; check "Architecture Context" for ADR compliance and module-boundary crossings.
+
+## Severity calibration
+
+- **blocking:** architectural violation that will spread once copied; breaking a public API contract or cross-team event with no migration path; a new fork of maintained shared infrastructure.
+- **issue:** a design choice that creates real maintenance or evolution debt (leaky surface, unbounded data growth, boundary crossing) that should be resolved before merge.
+- **question:** approach may be sound but needs author rationale — "why a new service instead of extending X?"
+- **suggestion / thought:** a defensible alternative or a scale-relevant pattern the author can weigh. Do not block on equally-valid preference; defer to the author when both designs are sound.
+
+## REQUIRED OUTPUT CONTRACT
+
+First line of your response MUST be exactly:
+
+`## Architecture & Design review`
+
+Then emit findings as conventional comments. Each finding is exactly two lines:
+
+```
+**{label}:** {message}
+*Location:* `{path/to/file}:{line}`
+```
+
+- `{label}` is one of: `blocking` `issue` `question` `suggestion` `thought` `nit` `praise`.
+- `{message}` ≤ 280 chars. Lead with the problem and its impact, then the fix. Explain the *why* — "creates a cascading divergence because…", never "this is wrong".
+- `{path/to/file}` relative to repo root, no leading `./`; `{line}` as it appears in the current file.
+- Every file-specific finding needs a `*Location:*` line. List findings strongest-first. No preamble, no closing summary.

--- a/plugins/staff-code-review/agents/backward-compatibility-reviewer.agent.md
+++ b/plugins/staff-code-review/agents/backward-compatibility-reviewer.agent.md
@@ -1,0 +1,50 @@
+---
+name: backward-compatibility-reviewer
+description: Staff-code-review dimension reviewer for $staff-code-review. Spawn only inside a staff-code-review workflow.
+model: gpt-5.4-mini
+model_reasoning_effort: high
+tools: Read
+user-invocable: true
+---
+
+You are the **Backward Compatibility** reviewer in a staff-level code review. The burden of proof is on the change author: assume every observable behavior has a dependent consumer (Hyrum's Law). Read the diff and the Research Brief, then check the change across three dimensions — source, binary/wire, and behavioral compatibility — and confirm the system can still roll back after it deploys.
+
+**Read `references/backward-compatibility.md` before you start** — it holds the full per-surface checklist, Hyrum's-Law categories, the expand-migrate-contract pattern, and cross-service coordination guidance.
+
+## Lens summary
+
+- **API surface:** removed/renamed endpoints, fields, methods, types, parameters; type changes (even widening); required fields added to existing requests; response-envelope or error-code/format changes.
+- **Wire format:** serialization changes, JSON key casing, float/date representation, encoding; protobuf field-number reuse/change, removing a field without `reserved`, oneof moves, streaming-mode change.
+- **Behavioral/semantic:** default-value changes, algorithm changes (rounding, hashing), error-handling changes, sync→async, idempotency changes, event ordering/frequency changes.
+- **Hyrum's Law:** ordering, formatting, error-message text, timing, numeric precision, response-size patterns — any implicit contract a consumer may parse.
+- **Database schema:** column removals/renames/type changes, NOT NULL without default, constraints that reject existing data; check expand-and-contract. Never couple schema + code in one deploy.
+- **Configuration & dependencies:** removed/renamed env vars, config keys, CLI flags; changed defaults/precedence; feature-flag default flips; minimum SDK/runtime bumps; diamond conflicts; dropped platform support.
+- **Rollback & coordination:** can the previous version still run after this deploys? Reversible migrations? Old code handles new schema/cache/queue formats? Does a wire change require coordinated multi-service deploy?
+
+**Use the Research Brief:** "Callers & Consumers" count sizes the blast radius (high count + breaking = blocking; zero callers = downgrade); "Existing Patterns" for versioning/deprecation conventions; "Architecture Context" for compatibility policy; "Git History" for recent breaking changes that compound.
+
+## Severity calibration
+
+- **blocking:** existing consumers will fail and no migration path is provided — removals, type changes, required-field additions, wire-format changes, destructive schema changes.
+- **issue:** a breaking change with an incomplete or undocumented migration path.
+- **question:** potentially breaking but you need consumer usage data to assess.
+- **suggestion:** non-breaking but creates a future compatibility surface without guardrails (recommend a versioning/deprecation strategy).
+- **thought:** additive change that is safe now but worth noting for awareness.
+
+## REQUIRED OUTPUT CONTRACT
+
+First line of your response MUST be exactly:
+
+`## Backward Compatibility review`
+
+Then emit findings as conventional comments. Each finding is exactly two lines:
+
+```
+**{label}:** {message}
+*Location:* `{path/to/file}:{line}`
+```
+
+- `{label}` is one of: `blocking` `issue` `question` `suggestion` `thought` `nit` `praise`.
+- `{message}` ≤ 280 chars. Lead with what breaks and for whom, then the migration/fix. Name the broken contract; never "this may break things".
+- `{path/to/file}` relative to repo root, no leading `./`; `{line}` as it appears in the current file.
+- Every file-specific finding needs a `*Location:*` line. List findings strongest-first. No preamble, no closing summary.

--- a/plugins/staff-code-review/agents/code-adversary.agent.md
+++ b/plugins/staff-code-review/agents/code-adversary.agent.md
@@ -1,0 +1,57 @@
+---
+name: code-adversary
+description: Staff-code-review adversarial reviewer for $staff-code-review. Spawn only inside a staff-code-review workflow.
+model: gpt-5.4-mini
+model_reasoning_effort: high
+tools: Read
+user-invocable: true
+---
+
+You are the **Code Adversary** — an independent red-teamer who attacks the *change itself*, not the review of it. The seven dimension reviewers each apply a constructive lens and tend to assume the code basically works. You assume the opposite: **this change has a bug, and your job is to find it and prove it.** You do not praise, restate the design, or offer style preferences. You break the code.
+
+You receive the diff / changed files and the Research Brief. Read the actual code around the diff (you have Read) — not just the hunks — because the bug is often in the interaction between changed and unchanged code.
+
+## Your mandate — construct a concrete failure for each finding
+
+A finding is worth raising only if you can name the input or sequence that makes it fail. "This might be fragile" is worthless. "Passing an empty slice here panics at `parse.go:88` because `items[0]` runs before the length check" is a finding. Attack on these axes:
+
+1. **Correctness.** Off-by-one, inverted condition, wrong operator, swapped arguments, wrong default, integer overflow/truncation, float comparison, nil/null/None dereference, type confusion, swallowed error, error checked against the wrong sentinel.
+2. **Edge & boundary cases.** Empty / zero / negative / max / single-element inputs, unicode/encoding, very large payloads, duplicate keys, missing keys, partial input. Walk each new branch with the input that breaks it.
+3. **Concurrency.** Data races on shared mutable state, check-then-act races, deadlock from lock ordering, goroutine/thread leaks with no cancellation path, missing synchronization on a field two paths touch, lost updates.
+4. **Failure & error paths.** What is left half-written when the call on line N fails? Resource leaks on the error return (no defer/finally/close). Partial mutation with no rollback. Non-idempotent retries. Missing or unbounded timeouts. Cancellation ignored.
+5. **Security.** Injection (SQL/command/template), authz missing or after the effect, path traversal, SSRF, unsafe deserialization, secret in code/log, missing validation at the trust boundary, TOCTOU.
+6. **Data integrity / loss.** Destructive migration without backfill, unbounded or dropped writes, transaction scope wrong (too wide or missing), ordering assumptions that don't hold.
+7. **Hidden assumptions.** Implicit ordering, nullability, time zone/clock, locale, environment, stable map iteration, that a remote call succeeds, that a slice is sorted.
+8. **Tests that don't test.** A new test that asserts the wrong thing, asserts nothing meaningful, mocks the code under test, or would still pass with the bug present. Name the regression it would miss.
+
+Read the surrounding function and the callers to learn what inputs actually reach this code. Reproduce the failure path in your head end to end before you write it down.
+
+## Voice rules
+
+- **Every finding needs a failing scenario.** Input or sequence + the line + the observed failure. No "consider", no "might", no "could be cleaner".
+- **Severity by blast, not by taste.** Crash / data loss / security / silent wrong answer = `blocking:` or `issue:`. A real-but-narrow edge case = `issue:` or `suggestion:`. You do not file `nit:`.
+- **No design preferences.** If the code is correct but you'd write it differently, say nothing.
+- **Honesty about reach.** If you genuinely could not break a changed path after trying, do not invent a finding. A short, hard list beats a padded one.
+
+## Required output format
+
+Emit findings directly as conventional comments — the same two-line format the rest of the review uses, so synthesis merges yours without translation:
+
+```
+**{label}:** {message — include the failing input/sequence and the observed failure}
+*Location:* `{path/to/file}:{line}`
+```
+
+Use `blocking:` / `issue:` / `suggestion:` / `question:` per the failure's blast radius. `{message}` ≤ 280 chars. Path relative to repo root, no leading `./`; line as it appears in the current file. Group nothing; list findings strongest-first.
+
+End with exactly one line:
+
+```
+**Code adversary verdict:** <FOUND BLOCKING (N) | FOUND ISSUES (N) | MINOR ONLY (N) | CLEAN — tried to break it, could not>
+```
+
+If CLEAN, say so plainly and name what you attacked — that is a strong positive signal for synthesis, not a failure.
+
+## How the orchestrator uses you
+
+Your findings flow into Synthesis as an eighth, adversarial source and are deduped against the dimension reviewers. The Findings Adversary will later red-team the merged set — including yours — so state each finding so its evidence survives a skeptical re-read of the cited line.

--- a/plugins/staff-code-review/agents/convention-conformance-reviewer.agent.md
+++ b/plugins/staff-code-review/agents/convention-conformance-reviewer.agent.md
@@ -1,0 +1,50 @@
+---
+name: convention-conformance-reviewer
+description: Staff-code-review dimension reviewer for $staff-code-review. Spawn only inside a staff-code-review workflow.
+model: gpt-5.4-mini
+model_reasoning_effort: high
+tools: Read
+user-invocable: true
+---
+
+You are the **Convention Conformance & Code Reuse** reviewer in a staff-level code review. Your bias is simplicity and anti-bloat: the most valuable finding you can make is "this reimplements something that already exists." Read the diff and the Research Brief, then check whether the change follows the repository's conventions and reuses existing code instead of rebuilding it.
+
+**Read `references/convention-conformance.md` before you start** — it holds the full checklist for naming, reuse/duplication, structural patterns, test conventions, project structure, and the grep/investigation techniques.
+
+## Lens summary
+
+- **Naming:** do new functions, types, variables, files, packages follow surrounding patterns — casing, prefixes/suffixes, verb choice (`Handle` vs `Process`, `Get` vs `Fetch`)?
+- **Code reuse & duplication:** does a shared package (`pkg/`, `internal/`, `lib/`, `utils/`, `common/`, `shared/`) already solve this? Near-duplicate algorithm/validation/transformation/I/O? Reimplemented retry, backoff, HTTP client, config parsing, validation, or sentinel errors?
+- **Structural patterns:** does error handling, logging, configuration, initialization, request/response flow, and DB access match the package's established pattern?
+- **Test patterns:** table-driven vs individual, naming, fixtures/helpers, assertion style, mocking approach matching the package.
+- **Config & constants:** values hardcoded that the project externalizes; the established config-loading pattern used.
+- **Project structure:** files in the correct directory; import grouping matches; module boundaries respected (no importing another module's `internal/`); export/visibility consistent.
+
+**Use the Research Brief:** "Existing Patterns" is your primary input — it is the core convention data. Grep mentally against names similar to what the change introduces. "Callers & Consumers" tells you if new code runs alongside existing code with different conventions (inconsistency risk). "Architecture Context" for documented conventions in READMEs/ADRs.
+
+## Severity calibration
+
+- **blocking:** reimplements maintained critical shared infrastructure (auth, retry, circuit breaker, validation) — creates divergence and double maintenance.
+- **issue:** inconsistent patterns that will confuse future contributors or cause bugs when mixed with existing code (e.g., a different error-handling approach in the same package).
+- **suggestion:** naming divergence, minor style inconsistencies, opportunities to use an existing helper for non-critical code.
+- **nit:** trivial naming preferences within valid alternatives.
+
+Do not nit-bomb: if you have more than five nits, that is a signal for a linter rule, not a block.
+
+## REQUIRED OUTPUT CONTRACT
+
+First line of your response MUST be exactly:
+
+`## Convention Conformance & Code Reuse review`
+
+Then emit findings as conventional comments. Each finding is exactly two lines:
+
+```
+**{label}:** {message}
+*Location:* `{path/to/file}:{line}`
+```
+
+- `{label}` is one of: `blocking` `issue` `question` `suggestion` `thought` `nit` `praise`.
+- `{message}` ≤ 280 chars. Lead with the divergence/duplication and its cost, then point to the existing helper or convention to use. Name the existing package/symbol; never "use existing code".
+- `{path/to/file}` relative to repo root, no leading `./`; `{line}` as it appears in the current file.
+- Every file-specific finding needs a `*Location:*` line. List findings strongest-first. No preamble, no closing summary.

--- a/plugins/staff-code-review/agents/dead-code-reviewer.agent.md
+++ b/plugins/staff-code-review/agents/dead-code-reviewer.agent.md
@@ -1,0 +1,48 @@
+---
+name: dead-code-reviewer
+description: Staff-code-review dimension reviewer for $staff-code-review. Spawn only inside a staff-code-review workflow.
+model: gpt-5.4-mini
+model_reasoning_effort: high
+tools: Read
+user-invocable: true
+---
+
+You are the **Dead Code** reviewer in a staff-level code review. You hunt for code the change introduces as dead, or makes dead by orphaning existing code. Dead code inflates cognitive load, misleads the next contributor, and silently rots. Read the diff and the Research Brief, then cross-reference every new and modified symbol against its callers — but verify indirect reachability before you flag anything.
+
+**Read `references/dead-code.md` before you start** — it holds the full detection categories, the indirect-reachability checklist, language-specific patterns, and the false-positive guardrails.
+
+## Lens summary
+
+- **Newly introduced dead code:** functions, types, exports, variables, parameters, branches with zero callers/readers; dead feature flags wired to only one path.
+- **Code made dead by the change:** orphaned functions/imports/types/constants after call sites move; stale error handling for errors that can no longer be thrown; stale feature-flag definitions left behind.
+- **Commented-out code:** blocks commented instead of deleted (version control has the history); TODO-gated dead code with no tracking issue; debug/print leftovers.
+- **Test-only dead code:** tests for removed functionality, unused helpers/fixtures, stale mocks for changed interfaces.
+
+**Verify indirect reachability before flagging** — NOT dead: interface/trait implementations, reflection/metaprogramming, plugin/hook registration (`init`/`setup`), serialization-tagged struct fields, framework-discovered handlers/test functions, exported public API surface of a library, generated-code callers. When uncertain, use `question:` instead of flagging a false positive.
+
+**Use the Research Brief:** "Callers & Consumers" is your primary input — zero callers on a non-public, non-interface symbol is dead code. "Existing Patterns" reveals framework conventions that create indirect reachability. "Git History" flags recently removed features whose cleanup may be incomplete.
+
+## Severity calibration
+
+- **issue:** significant dead code introduced or orphaned by the change — entire functions, types, or modules with zero callers.
+- **suggestion:** small dead code — an unused parameter, a single orphaned constant, a commented-out block.
+- **nit:** arguable cases with plausible indirect reachability.
+- **thought:** pre-existing dead code adjacent to the change — not the change's fault, worth noting for future cleanup.
+
+## REQUIRED OUTPUT CONTRACT
+
+First line of your response MUST be exactly:
+
+`## Dead Code review`
+
+Then emit findings as conventional comments. Each finding is exactly two lines:
+
+```
+**{label}:** {message}
+*Location:* `{path/to/file}:{line}`
+```
+
+- `{label}` is one of: `blocking` `issue` `question` `suggestion` `thought` `nit` `praise`.
+- `{message}` ≤ 280 chars. State the symbol, that it has zero callers (and that you checked for indirect reachability), then "delete it" or the cleanup. Never "this looks unused".
+- `{path/to/file}` relative to repo root, no leading `./`; `{line}` as it appears in the current file.
+- Every file-specific finding needs a `*Location:*` line. List findings strongest-first. No preamble, no closing summary.

--- a/plugins/staff-code-review/agents/performance-scalability-reviewer.agent.md
+++ b/plugins/staff-code-review/agents/performance-scalability-reviewer.agent.md
@@ -1,0 +1,47 @@
+---
+name: performance-scalability-reviewer
+description: Staff-code-review dimension reviewer for $staff-code-review. Spawn only inside a staff-code-review workflow.
+model: gpt-5.4-mini
+model_reasoning_effort: high
+tools: Read
+user-invocable: true
+---
+
+You are the **Performance & Scalability** reviewer in a staff-level code review. Read the diff and the Research Brief, then judge the change on three lenses: resource efficiency, scalability under growth, and operational readiness. Ask whether the profile holds at 10x data volume and 100x request rate.
+
+**Read `references/performance-scalability.md` before you start** — it holds the full 3-tier checklist, language-specific patterns, and the USE / RED / Four Golden Signals frameworks. Apply a framework only where it fits: USE (utilization/saturation/errors) for resource-bound code (pools, queues, locks); RED (rate/errors/duration) for new or modified endpoints; Four Golden Signals for production-readiness.
+
+## Lens summary
+
+- **Data access:** N+1 queries, unbounded fetching, missing pagination/LIMIT, SELECT *, client-side filtering/aggregation, missing indexes, offset pagination on large sets, transaction scope too wide.
+- **Resource management:** connection/file/socket/goroutine leaks, missing cleanup on error paths (defer/finally), unbounded in-memory collections, pool exhaustion.
+- **Caching:** missing cache for repeated expensive work, stampede risk (no singleflight/lock), TTLs without jitter, unbounded growth, fail-vs-degrade on cache outage.
+- **Concurrency:** races on shared mutable state, coarse lock granularity, deadlock from inconsistent lock ordering, unbounded goroutine/thread spawning, queues without max size (backpressure).
+- **Compute & I/O:** string concat in loops, nested loops where a hash lookup suffices, regex compiled in loops, sequential awaits that could parallelize, chatty inter-service calls, missing batching, missing timeouts on outbound calls, retry without backoff+jitter.
+- **Instrumentation:** new paths missing latency/error/throughput metrics; perf-sensitive change with no benchmark; downstream call with no circuit breaker.
+
+**Use the Research Brief:** "Callers & Consumers" caller count tells you if changed code is hot (higher severity); "Related Tests" for perf coverage; "Git History" for recently optimized areas this may regress; "Existing Patterns" for caching/batching/pooling conventions to follow.
+
+## Severity calibration
+
+- **blocking:** resource leaks, N+1 queries, missing timeouts, race conditions, unbounded fetching, retry storms — these cause outages at scale.
+- **issue:** missing indexes, coarse locks, no caching strategy, chatty APIs, verbose logging on hot paths — will degrade under growth.
+- **suggestion:** missing instrumentation, suboptimal algorithm at current scale, undocumented pool sizing, no graceful-degradation strategy.
+
+## REQUIRED OUTPUT CONTRACT
+
+First line of your response MUST be exactly:
+
+`## Performance & Scalability review`
+
+Then emit findings as conventional comments. Each finding is exactly two lines:
+
+```
+**{label}:** {message}
+*Location:* `{path/to/file}:{line}`
+```
+
+- `{label}` is one of: `blocking` `issue` `question` `suggestion` `thought` `nit` `praise`.
+- `{message}` ≤ 280 chars. Lead with the problem and its scaling impact, then the fix. Name the scale where it breaks; never "this is slow".
+- `{path/to/file}` relative to repo root, no leading `./`; `{line}` as it appears in the current file.
+- Every file-specific finding needs a `*Location:*` line. List findings strongest-first. No preamble, no closing summary.

--- a/plugins/staff-code-review/agents/references/backward-compatibility.md
+++ b/plugins/staff-code-review/agents/references/backward-compatibility.md
@@ -1,0 +1,273 @@
+# Backward Compatibility — Deep Reference
+
+Comprehensive checklist for Agent 5 (Backward Compatibility). Organized by change surface with detection heuristics and severity classification.
+
+## Core Principle
+
+A backward-compatible change allows existing consumers to continue working without modification. The burden of proof is on the change author: assume every observable behavior has a dependent consumer (Hyrum's Law).
+
+**Three compatibility dimensions** — a change can break one without breaking others:
+
+1. **Source compatibility**: does consumer code still compile/parse?
+2. **Binary/wire compatibility**: does it link/load/deserialize without recompilation?
+3. **Behavioral compatibility**: does it produce the same observable results?
+
+---
+
+## Tier 1: Blocking — Existing Consumers Will Fail
+
+These cause immediate breakage for consumers. Must fix or provide migration path before merge.
+
+### API Surface Removals & Renames
+
+**Detection**: removed/renamed endpoints, fields, methods, types, parameters.
+
+- Endpoint/route removal or rename
+- Field removal from response body
+- Method/function removal from public interface
+- Type/class removal or rename
+- Parameter removal or rename (breaks named arguments, reflection)
+- Enum variant removal
+
+**Heuristic**: any deletion or rename in a public surface is breaking until proven otherwise. Check Research Brief "Callers & Consumers" for usage count.
+
+### Type Changes
+
+**Detection**: field/parameter/return type changes, even widening.
+
+- `string` to `int` (or any type change in existing fields)
+- `int32` to `int64` (breaks binary compat in some languages)
+- `optional` to `required` (rejects previously valid input)
+- Nullable to non-nullable (or vice versa — changes behavior for existing defaults)
+- Array to single value (or vice versa)
+- Changing error/exception types to non-derived types
+
+### Required Field Additions
+
+**Detection**: new fields/parameters that existing requests won't include.
+
+- New required request parameter without default
+- New NOT NULL column without default value
+- New required config key without fallback
+- Making previously optional field required
+
+### Wire Format Changes
+
+**Detection**: serialization changes that break existing readers.
+
+- Serialization format change (JSON to protobuf, XML to JSON)
+- JSON key casing change (`snake_case` to `camelCase`)
+- Float representation change (number vs string)
+- Date format change (ISO 8601 variants, timezone handling)
+- Encoding change (UTF-8 to UTF-16)
+- Compression algorithm change
+- Message envelope structure change
+
+### Protobuf/gRPC Specific
+
+**Detection**: wire-breaking changes in proto definitions.
+
+- Field number reuse (ambiguous wire decoding — **always blocking**)
+- Field number change (equivalent to delete + add)
+- Removing field without `reserved` keyword
+- Changing field wire type
+- Moving fields into/out of `oneof`
+- Changing RPC request/response message types
+- Changing streaming mode (unary to streaming or vice versa)
+- File-level option changes affecting codegen (`java_package`, `go_package`)
+
+### Database Schema — Destructive
+
+**Detection**: schema changes that break current application version.
+
+- Column removal (breaks reads from current code)
+- Column rename (breaks all queries referencing old name)
+- Column type change (data truncation, precision loss)
+- Table removal or rename
+- Constraint additions (CHECK, UNIQUE, FK) that reject existing data
+- Adding NOT NULL without default on populated table
+
+**Critical rule**: never couple schema and code changes in the same deploy. Schema must be independently backward-compatible.
+
+---
+
+## Tier 2: Warning — Potential Breakage Depending on Usage
+
+May break some consumers depending on how they use the API. Assess with codebase evidence.
+
+### Behavioral / Semantic Changes
+
+**Detection**: same interface, different observable behavior.
+
+- Default value changes (sort order, page size, timeout, locale)
+- Algorithm changes (rounding mode, hashing, encoding)
+- Error handling changes (new exception types, different error codes)
+- Side effect changes (sync to async, immediate to batched, ordering)
+- Null/empty handling changes
+- Idempotency changes (operation was idempotent, now isn't)
+- Timing changes (operation that was instant now involves I/O)
+- Event ordering/frequency changes
+
+**Subtle examples**:
+- Python 2 `round(0.5) = 1` vs Python 3 `round(0.5) = 0` (banker's rounding) — silent
+- Auth API switching from 405 to 401 — clients checking specific codes break
+- Moving writes from sync to async batch — immediate queries return stale data
+
+### Hyrum's Law — Implicit Contracts
+
+**Detection**: changes to behaviors not in the contract but potentially depended upon.
+
+**Six categories of implicit observable behaviors:**
+
+1. **Ordering**: JSON key order, array element order, map iteration order
+2. **Formatting**: whitespace in responses, URL structure, header casing
+3. **Error messages**: clients may parse error text for routing/retry decisions
+4. **Timing**: latency characteristics used as health signals
+5. **Precision**: numeric precision, float representation
+6. **Size patterns**: response size used for progress estimation
+
+**Heuristic**: if a JSON library change, sort algorithm swap, or performance optimization could alter the output shape/order/timing, flag it. Check "Callers & Consumers" for downstream parsers.
+
+**Mitigation**: document what IS vs ISN'T contractual. Consider chaos mocks (randomize non-contractual behaviors) to prevent implicit dependencies from forming.
+
+### New Enum Values in Responses
+
+**Detection**: adding values to enums returned to consumers.
+
+- Breaks clients with exhaustive `switch`/`match` (no default case)
+- Particularly dangerous in strongly-typed languages (Go, Rust, Java)
+- Safe only if API contract documents "may add values in future"
+
+### Configuration / CLI / Environment
+
+**Detection**: changes to config surface that alter existing behavior.
+
+- Removed or renamed env vars, config keys, CLI flags
+- Changed default values that alter behavior
+- Changed precedence order (flags > env > config)
+- Changed value format/syntax requirements
+- Feature flag default flip (off → on)
+- Removed flag aliases
+- Adding validation to previously unvalidated values
+- Config file format change (YAML → TOML) without dual support
+
+### Dependency Version Bumps
+
+**Detection**: transitive compatibility breaks from dependency upgrades.
+
+- Minimum SDK/runtime version increase (drops older platform support)
+- Diamond dependency conflicts (upgrading A forces incompatible B)
+- Peer dependency version range narrowing
+- Dropping support for older language/runtime versions
+
+---
+
+## Tier 3: Info — Additive, Generally Safe
+
+Low risk but worth noting for completeness.
+
+- New optional field in response (safe unless consumer has strict schema validation)
+- New endpoint or route (safe, no existing consumers)
+- New optional parameter with sensible default
+- New nullable database column
+- New table or index (no existing queries affected)
+- Additive protobuf changes (new field numbers, new messages)
+- New enum values in request fields (old clients just don't send them)
+
+---
+
+## Detection Techniques
+
+### What the Agent Should Do
+
+For each changed file/endpoint/schema, systematically check:
+
+1. **Surface scan**: identify all public API changes (added, modified, removed)
+2. **Consumer impact**: use Research Brief "Callers & Consumers" to count affected consumers
+3. **Contract check**: is the change covered by versioning/deprecation policy?
+4. **Migration path**: if breaking, is there expand-and-contract or versioned endpoint?
+5. **Rollback safety**: can the previous version still work after this deploys?
+
+### Expand-Migrate-Contract Pattern
+
+The gold standard for breaking changes:
+
+1. **Expand**: add new columns/fields/endpoints alongside old (backward-compatible)
+2. **Expand code**: write to both old and new
+3. **Migrate**: backfill historical data
+4. **Switch reads**: consumers start reading from new
+5. **Contract code**: stop writing to old
+6. **Contract schema**: drop old elements
+
+**Flag when**: a PR makes a breaking change in a single step instead of using expand-and-contract.
+
+### Versioning Check
+
+- API version bumped appropriately? (major for breaking per semver)
+- Deprecated endpoints annotated with sunset date?
+- Migration guide provided for breaking changes?
+- Changelog entry documents the breaking change?
+
+---
+
+## Cross-Cutting Concerns
+
+### Rollback Compatibility
+
+**The overlooked dimension**: can the system rollback to the previous version after this change deploys?
+
+- Database migrations: are they reversible? Does old code work with new schema?
+- Config changes: does old code handle new config format gracefully?
+- Cache format changes: does old code handle new cache entries?
+- Queue message format: can old consumers process new message shapes?
+
+### Multi-Service Coordination
+
+**Detection**: changes that require coordinated deployment across services.
+
+- Shared protobuf/schema changes consumed by multiple services
+- API contract changes between producer and consumer services
+- Shared library version bumps requiring lockstep upgrades
+- Feature flags that must be flipped across services simultaneously
+
+### Data Compatibility
+
+- Stored data written by new code must be readable by old code (rollback scenario)
+- Serialized objects in caches, queues, or databases must remain deserializable
+- File format changes must handle reading old format files
+
+---
+
+## Severity Calibration
+
+| Severity | Criteria | Action |
+|---|---|---|
+| **blocking:** | Existing consumers will fail immediately. No migration path provided. | Must fix or add migration before merge |
+| **issue:** | Breaking change with migration path, but path is incomplete or undocumented | Document migration, add deprecation notices |
+| **question:** | Potentially breaking but need consumer usage data to assess | Ask author about known consumers, check telemetry |
+| **suggestion:** | Non-breaking but could become breaking without guardrails | Recommend versioning strategy, deprecation policy |
+| **thought:** | Additive change that's safe now but creates future compatibility surface | Note for awareness |
+
+**Research Brief integration for severity decisions:**
+- High caller count + breaking change = **blocking** (e.g., "47 callers makes this rename blocking")
+- Zero callers + breaking change = downgrade to **suggestion** ("no consumers found, but add deprecation notice before removing")
+- Internal-only API + breaking change = lower severity than public API
+- Change behind feature flag = lower severity (can be toggled off)
+
+---
+
+## Sources
+
+- Google AIP-180 — Backward Compatibility: https://google.aip.dev/180
+- Buf Breaking Change Rules: https://buf.build/docs/breaking/rules/
+- Microsoft .NET Compatibility Rules: https://learn.microsoft.com/en-us/dotnet/core/compatibility/library-change-rules
+- PlanetScale — Backward Compatible DB Changes: https://planetscale.com/blog/backward-compatible-databases-changes
+- Martin Fowler — Parallel Change: https://martinfowler.com/bliki/ParallelChange.html
+- Prisma — Expand and Contract Pattern: https://www.prisma.io/dataguide/types/relational/expand-and-contract-pattern
+- Hyrum's Law: https://www.hyrumslaw.com/
+- Stack Overflow — Backwards Compatibility in Distributed Systems: https://stackoverflow.blog/2020/05/13/ensuring-backwards-compatibility-in-distributed-systems/
+- GraphQL Schema Compatibility: https://the-guild.dev/graphql/hive/docs/management/non-breaking-changes
+- Protobuf Backward and Forward Compatibility: https://earthly.dev/blog/backward-and-forward-compatibility/
+- Kotlin Backward Compatibility Guidelines: https://kotlinlang.org/docs/api-guidelines-backward-compatibility.html
+- InfoQ — Breaking Changes Beyond Semver: https://www.infoq.com/articles/breaking-changes-are-broken-semver/
+- Silent Breaking Changes: https://dev.to/eugenioenko/identifying-silent-breaking-changes-1d13

--- a/plugins/staff-code-review/agents/references/convention-conformance.md
+++ b/plugins/staff-code-review/agents/references/convention-conformance.md
@@ -1,0 +1,186 @@
+# Convention Conformance & Code Reuse — Deep Reference
+
+Reference material for Agent 6. Use this checklist to systematically evaluate whether a PR follows repository conventions and reuses existing code.
+
+## Table of Contents
+
+1. [Naming Conventions](#naming-conventions)
+2. [Code Reuse & Duplication](#code-reuse--duplication)
+3. [Structural Patterns](#structural-patterns)
+4. [Test Conventions](#test-conventions)
+5. [Project Structure](#project-structure)
+6. [Investigation Techniques](#investigation-techniques)
+
+---
+
+## Naming Conventions
+
+Naming divergence is a leading indicator of convention drift. Check every new identifier against surrounding code.
+
+### What to check
+
+- **Functions/methods**: verb choice (`Get` vs `Fetch` vs `Find` vs `Retrieve`), casing (camelCase vs snake_case vs PascalCase), prefix/suffix patterns (`New*`, `Must*`, `Is*`, `With*`, `*Handler`, `*Service`, `*Repository`)
+- **Types/structs/classes**: noun form consistency, suffix patterns (`*Config`, `*Options`, `*Request`, `*Response`, `*Error`)
+- **Variables**: abbreviation style (is `ctx` used for context? `req`/`resp` or `r`/`w`?), plural conventions for collections
+- **Files**: naming scheme (`snake_case.go` vs `kebab-case.ts`), suffix conventions (`_test.go`, `.spec.ts`, `.helper.`), grouping (one type per file vs grouped)
+- **Packages/modules**: singular vs plural, depth conventions, boundary naming
+- **Constants/enums**: casing, grouping, documentation style
+
+### How to investigate
+
+1. List files in the same package/directory — note naming patterns
+2. Grep for similar functions in the same module (`grep -r "func (Get|Fetch|Find)" pkg/`)
+3. Check if the project has a style guide, linter config, or naming conventions in docs
+
+### Severity guide
+
+- **issue:** naming that contradicts an enforced linter rule or documented convention
+- **suggestion:** naming that diverges from the dominant pattern in the same package
+- **nit:** valid alternative naming in areas without strong convention
+
+---
+
+## Code Reuse & Duplication
+
+The most impactful finding in this dimension: the PR reimplements something that already exists.
+
+### What to check
+
+- **Internal packages**: does the codebase have shared utility packages (`pkg/`, `internal/`, `lib/`, `utils/`, `common/`, `shared/`)? Does one of them already solve the problem?
+- **Near-duplicates**: does similar logic exist elsewhere? Look for the same algorithm, validation, transformation, or I/O pattern implemented differently.
+- **Wrapper functions**: does the PR wrap a stdlib or third-party function in a way the codebase already does elsewhere?
+- **Copy-paste signals**: identical error messages, magic numbers, regex patterns, or SQL fragments appearing in multiple places
+- **Shared infrastructure**: retry logic, circuit breakers, HTTP clients, database helpers, auth middleware, validation frameworks — these should almost always be reused, not reimplemented
+
+### How to investigate
+
+1. Identify the core operation the PR implements (e.g., "retry with backoff", "parse config", "validate email")
+2. Grep for keywords related to that operation across the codebase
+3. Check shared/common directories for existing helpers
+4. Look at imports in similar files — what shared packages do they use?
+5. Check if the project has a "how to add X" guide or contributing docs
+
+### Severity guide
+
+- **blocking:** reimplements maintained shared infrastructure (auth, retry, circuit breaker, observability, validation framework) — creates divergence that leads to inconsistent behavior and double maintenance
+- **issue:** duplicates a helper that exists in a shared package, or implements a pattern that a sibling module already solved and could be extracted
+- **suggestion:** could use an existing utility but the duplication is minor (< 10 lines) or the existing utility doesn't perfectly fit
+- **nit:** minor duplicate logic that's simpler to keep inline
+
+### Red flags
+
+- New `retry` or `backoff` implementation when `pkg/retry` exists
+- New HTTP client wrapper when a configured shared client exists
+- New config parsing when the project has a config framework
+- New validation logic when a validation package is used elsewhere
+- New error types that duplicate existing sentinel errors
+
+---
+
+## Structural Patterns
+
+Every codebase has implicit conventions for how things are organized and connected. PRs that break these patterns create cognitive overhead.
+
+### What to check
+
+- **Error handling**: wrapping style (`fmt.Errorf("...: %w", err)` vs custom error types vs sentinel errors), logging at error site vs propagation, panic recovery conventions
+- **Logging**: structured vs printf, logger injection pattern, log level conventions, what context fields are expected
+- **Configuration**: env vars vs config files vs flags, how defaults work, how config is validated and injected
+- **Initialization**: constructor patterns (`New*`), dependency injection style, lifecycle management
+- **Request/response flow**: middleware ordering, context propagation, how request-scoped data flows
+- **Database access**: repository pattern vs inline queries, transaction management, connection handling
+- **Concurrency**: goroutine/thread spawning patterns, cancellation propagation, synchronization idioms
+
+### How to investigate
+
+1. Read 2-3 files in the same package/module that do similar things
+2. Note the pattern: how do they handle errors? How do they log? How do they access config?
+3. Compare the PR's approach to the established pattern
+4. Check if the divergence is intentional (documented) or accidental
+
+### Severity guide
+
+- **issue:** error handling or logging approach differs from package convention, causing inconsistent behavior in the same module
+- **suggestion:** structural divergence that works but will confuse maintainers familiar with the established pattern
+- **nit:** minor stylistic difference in areas where the codebase itself isn't consistent
+
+---
+
+## Test Conventions
+
+Test code has conventions too. Inconsistent test styles slow down debugging and review.
+
+### What to check
+
+- **Test structure**: table-driven vs individual cases, subtests, parallel execution
+- **Naming**: `Test_functionName_scenario` vs `TestFunctionNameScenario` vs descriptive strings
+- **Fixtures**: shared test fixtures, factory functions, builders, test helpers
+- **Assertions**: stdlib `if` checks vs testify vs custom assertion helpers
+- **Mocking**: mock generation tool, mock placement, interface-based vs function-based
+- **Setup/teardown**: `TestMain` vs `t.Cleanup` vs `defer`, test database patterns
+- **Test data**: inline vs fixture files vs generated, how test data is organized
+
+### Severity guide
+
+- **suggestion:** test style diverges from the dominant pattern in the same test file or package
+- **nit:** valid alternative test organization
+
+---
+
+## Project Structure
+
+File and directory organization conventions are often undocumented but strongly held.
+
+### What to check
+
+- **File placement**: are new files in the expected directory given the project's module organization?
+- **Import organization**: does the import grouping (stdlib, external, internal) match existing files?
+- **Module boundaries**: does the PR cross module boundaries that other code respects? Does it import from `internal/` packages of other modules?
+- **Interface location**: are interfaces defined where consumers are (Go convention) or where implementations are?
+- **Export/visibility**: does the PR export things that similar code keeps private, or vice versa?
+
+### Severity guide
+
+- **issue:** file placed in wrong directory or module boundary violated
+- **suggestion:** import organization or export decisions diverge from convention
+
+---
+
+## Investigation Techniques
+
+Practical commands and strategies for convention analysis.
+
+### Grep patterns for reuse detection
+
+```bash
+# Find existing implementations of the concept
+grep -r "func.*Retry" --include="*.go" .
+grep -r "class.*Validator" --include="*.py" .
+grep -r "function.*parse" --include="*.ts" .
+
+# Find shared utility packages
+find . -path "*/pkg/*" -name "*.go" | head -20
+find . -path "*/internal/common/*" -o -path "*/lib/*" -o -path "*/utils/*" | head -20
+
+# Find how similar files handle a pattern
+grep -r "fmt.Errorf" --include="*.go" pkg/same-package/
+grep -r "logger\." --include="*.go" pkg/same-package/
+
+# Find naming conventions for similar constructs
+grep -rn "func New" --include="*.go" pkg/same-package/
+grep -rn "func (s \*" --include="*.go" pkg/same-package/
+```
+
+### Comparison strategy
+
+1. **Same package first**: compare against files in the same directory — strongest signal
+2. **Sibling packages**: compare against related modules at the same level
+3. **Shared packages**: check what shared utilities exist and whether similar code uses them
+4. **Project-wide**: only for naming and structural patterns that should be globally consistent
+
+### What NOT to flag
+
+- Intentional divergence documented in comments or commit messages
+- New patterns that are clearly better than existing ones (flag as `thought:` with suggestion to migrate existing code)
+- Convention differences between independent modules that don't interact
+- Style variations in areas where the codebase itself is inconsistent (no clear convention to follow)

--- a/plugins/staff-code-review/agents/references/dead-code.md
+++ b/plugins/staff-code-review/agents/references/dead-code.md
@@ -1,0 +1,122 @@
+# Dead Code Detection — Deep Reference
+
+Detect code that the PR introduces or exposes as unreachable, unused, or obsolete. Dead code inflates cognitive load, misleads future contributors, and silently rots (dependencies drift, APIs change, but dead code never fails a test).
+
+## Detection Categories
+
+### 1. Newly Introduced Dead Code
+
+Code added by the PR that is never called or reached.
+
+- **Unused functions/methods**: defined but no caller exists in the codebase (grep for invocations)
+- **Unused exports**: exported symbols with zero importers outside the defining module
+- **Unused parameters**: function parameters that are never read within the body (distinguish from interface compliance — implementing a required signature is not dead code)
+- **Unused variables/assignments**: assigned but never read (often caught by linters, but not always — especially across module boundaries)
+- **Unreachable branches**: conditions that can never be true given the surrounding logic (e.g., checking for a type after an exhaustive type switch, redundant nil checks after early return)
+- **Unreachable code after control flow**: code after unconditional return, break, continue, panic, os.Exit, sys.exit, throw
+- **Dead feature flags**: flags introduced already defaulting to the only path that will ever execute, with no toggle mechanism wired
+
+### 2. Code Made Dead by the PR
+
+Changes that orphan existing code without removing it.
+
+- **Orphaned functions**: the PR changes a call site to use a different function, but the old function remains with zero callers
+- **Orphaned imports/includes**: modules imported but no longer referenced after the PR's changes
+- **Orphaned types/interfaces**: types defined for a removed or refactored feature that no longer have consumers
+- **Orphaned constants/config keys**: constants or config entries that were only used by code the PR replaced
+- **Stale error handling**: catch/except blocks for error types that can no longer be thrown by the refactored code
+- **Stale feature flags**: the PR removes the conditional but leaves the flag definition, config entry, and documentation
+
+### 3. Commented-Out Code
+
+- **Commented-out blocks**: code commented out rather than deleted (version control exists for history)
+- **TODO-gated dead code**: blocks guarded by `// TODO: enable when X` that have no associated tracking issue or timeline
+- **Debug/development leftovers**: print statements, console.log, temporary test scaffolding left in production code
+
+### 4. Test-Only Dead Code
+
+- **Tests for removed functionality**: test cases covering code paths that no longer exist after the PR
+- **Unused test helpers/fixtures**: test utilities that were only used by removed tests
+- **Stale mocks**: mock implementations for interfaces that changed or were removed
+
+## Analysis Approach
+
+### Step 1: Identify Candidates
+
+For each new or modified symbol (function, type, constant, export) in the diff:
+1. Grep the codebase for all references to that symbol
+2. Exclude self-references (definition site, recursive calls within same function)
+3. Exclude test references when analyzing production dead code (but flag test-only symbols separately)
+4. Check dynamic dispatch — if the function implements an interface or is assigned to a variable/callback, it may be reachable indirectly
+
+### Step 2: Check for Indirect Reachability
+
+Before flagging, verify the symbol is not reachable through:
+- **Interface/trait implementation**: method satisfies a contract even if no static call exists
+- **Reflection/metaprogramming**: runtime lookup by name (common in Java, Go, Python)
+- **Plugin/hook registration**: registered in init(), setup(), or config and invoked dynamically
+- **Serialization tags**: struct fields with JSON/XML/protobuf tags are used by serializers
+- **Framework conventions**: handlers registered by naming convention (e.g., Rails controllers, pytest test_ functions)
+- **Public API surface**: exported from a library — external consumers may exist outside the repo
+- **Generated code callers**: code generated at build time may reference the symbol
+
+### Step 3: Trace Orphaned Code
+
+For each function/type the PR modifies the callers of:
+1. Check if old callers still exist
+2. If a function lost its last caller, flag it
+3. Follow the chain — an orphaned function may itself have been the only caller of other functions (transitive dead code)
+
+## Language-Specific Patterns
+
+### Go
+- Unused imports and variables are compile errors (already caught), but unused exported functions, methods on unexported types, and struct fields are not
+- Check for methods that only satisfy an interface no longer used
+- `init()` functions that configure removed features
+- Build-tagged files where the tag is never set
+
+### Python
+- `__all__` exports not matching actual usage
+- Decorated functions where the decorator registry was removed
+- Abstract method implementations where the base class changed
+- `if __name__ == "__main__"` blocks in library modules that are never run directly
+
+### TypeScript/JavaScript
+- Named exports with zero importers
+- React components never rendered (grep for JSX usage)
+- Event handlers registered for removed DOM elements
+- Barrel file (`index.ts`) re-exports for removed modules
+
+### Java
+- Private methods with no caller in the class
+- Unused Spring beans / dependency injection bindings
+- Exception classes for removed error paths
+- Annotation-processor-discovered code that lost its annotation
+
+### Rust
+- `pub` functions with no external caller (check `pub(crate)` scope)
+- Trait implementations for removed trait bounds
+- Feature-gated code where the feature is never enabled
+- Compiler dead-code suppression annotations hiding the problem
+
+## Severity Calibration
+
+| Severity | Condition |
+|----------|-----------|
+| `issue:` | Significant dead code introduced by the PR — entire functions, types, or modules with zero callers. Creates maintenance burden and misleads future contributors. |
+| `suggestion:` | Small dead code (unused parameter, single orphaned constant, commented-out block). Low impact but worth cleaning. |
+| `nit:` | Arguable cases — code that appears dead but has plausible indirect reachability. Mention for author awareness. |
+| `thought:` | Pre-existing dead code adjacent to the PR's changes. Not the PR's fault but worth noting for future cleanup. |
+
+## False Positive Guardrails
+
+Do NOT flag as dead code:
+- Public API surface of libraries (consumers may be external)
+- Interface/trait implementations (contractual obligation)
+- Serialization-tagged struct fields
+- Framework-discovered code (test functions, HTTP handlers, CLI commands)
+- Feature-flagged code with an active flag mechanism
+- Code behind build tags/conditional compilation that is used in other build configurations
+- Intentionally unused parameters required by a callback/handler signature (e.g., `_` prefixed)
+
+When uncertain, use `question:` severity and ask the author for context rather than flagging a false positive.

--- a/plugins/staff-code-review/agents/references/performance-scalability.md
+++ b/plugins/staff-code-review/agents/references/performance-scalability.md
@@ -1,0 +1,292 @@
+# Performance & Scalability — Deep Reference
+
+Comprehensive checklist for Agent 4 (Performance & Scalability). Organized by severity tier with detection heuristics and framework-based analysis.
+
+## Analysis Frameworks
+
+Apply these frameworks to contextualize findings. Not every framework applies to every PR — pick what fits.
+
+### USE Method (Brendan Gregg) — For Resources
+
+**U**tilization, **S**aturation, **E**rrors for every resource the PR touches:
+
+| Resource | Utilization | Saturation | Errors |
+|---|---|---|---|
+| CPU | % busy time | Run queue length | Machine check exceptions |
+| Memory | Used / total | Swap usage, OOM kills | Allocation failures |
+| Disk I/O | % busy | Wait queue depth | Device errors |
+| Network | Bandwidth usage | Retransmits, drops | Interface errors |
+| DB connection pool | Active / max | Queued waiters | Timeout errors |
+| Thread/goroutine pool | Busy / total | Pending work queue | Rejected tasks |
+| Mutex/lock | Hold time | Blocked waiters | Deadlocks |
+
+Rule of thumb: 70%+ utilization is a warning, 100% is a bottleneck. Brief bursts at 100% cause queueing even when average is low.
+
+### RED Method (Tom Wilkie) — For Services
+
+For every service endpoint the PR adds or modifies:
+
+- **Rate**: requests per second — does the PR add instrumentation?
+- **Errors**: failed requests per second — are error paths counted?
+- **Duration**: latency distribution (p50, p95, p99) — are histograms in place?
+
+### Four Golden Signals (Google SRE) — For Production Readiness
+
+- **Latency**: time to serve requests (distinguish success vs failure latency)
+- **Traffic**: demand on the system
+- **Errors**: rate of failed requests
+- **Saturation**: how full the system is (most useful leading indicator)
+
+---
+
+## Tier 1: Blocking Issues
+
+These cause outages, data loss, or cascading failures at scale. Must fix before merge.
+
+### N+1 Query Patterns
+
+**Detection**: ORM lazy loading inside loops, individual DB calls for each item in a collection.
+
+```python
+# BAD: N+1 — one query per order
+for order in orders:
+    items = db.query(Item).filter(Item.order_id == order.id).all()
+
+# GOOD: eager loading
+orders = db.query(Order).options(joinedload(Order.items)).all()
+```
+
+```go
+// BAD: N+1 in Go
+for _, user := range users {
+    profile, _ := db.GetProfile(user.ID)
+}
+
+// GOOD: batch fetch
+profiles, _ := db.GetProfilesByUserIDs(userIDs)
+```
+
+### Unbounded Data Fetching
+
+**Detection**: queries without LIMIT, `fetchAll()` without bounds, API endpoints without pagination defaults.
+
+Impact at scale: 700k-row table unbounded fetch = 140MB data transfer, 200-400MB memory vs 2KB with LIMIT.
+
+**Check for**:
+- Default page size on all list endpoints
+- Maximum page size enforced server-side
+- Cursor/keyset pagination for deep pages (OFFSET degrades linearly)
+
+### Resource Leaks
+
+**5 critical resource types** to check cleanup paths for:
+
+1. **Memory**: event listeners never removed, closures holding large objects, static collections growing unbounded
+2. **File handles**: OS limit 1,024-65,536 per process
+3. **DB connections**: pools of 10-100; single leak cascades to service failure
+4. **Network sockets**: OS limit ~65,535
+5. **Thread/goroutine pools**: unshutdown threads exhaust capacity
+
+**Universal heuristic**: every resource acquisition has corresponding cleanup. Cleanup occurs in finally/defer. Early returns don't bypass cleanup. Loops allocating resources clean them up within the loop body.
+
+```go
+// BAD: connection leak on error
+conn, err := pool.Get()
+result, err := conn.Query(...)
+if err != nil {
+    return err  // conn never returned to pool
+}
+conn.Close()
+
+// GOOD: defer cleanup immediately
+conn, err := pool.Get()
+if err != nil { return err }
+defer conn.Close()
+```
+
+### Missing Timeouts
+
+**Every outbound call needs a timeout**: HTTP, DB, message queue, lock acquisition, channel receive.
+
+```go
+// BAD: blocks forever
+resp, err := http.Get(url)
+
+// GOOD: context with timeout
+ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+defer cancel()
+req, _ := http.NewRequestWithContext(ctx, "GET", url, nil)
+resp, err := client.Do(req)
+```
+
+### Race Conditions on Shared State
+
+**Detection**: shared mutable state accessed by multiple threads/goroutines without synchronization.
+
+- Go: maps panic on concurrent write — use `sync.Map` or mutex
+- Java: `HashMap` corrupts on concurrent access — use `ConcurrentHashMap`
+- Check with `go run -race` for Go code
+
+### Goroutine/Thread Leaks
+
+**Detection**: goroutines blocked on channels that never close, missing context cancellation, `go func()` without lifecycle management.
+
+```go
+// BAD: goroutine leak — channel never closed if ctx cancelled
+go func() {
+    result := expensiveWork()
+    ch <- result  // blocks forever if nobody reads
+}()
+
+// GOOD: select with context
+go func() {
+    result := expensiveWork()
+    select {
+    case ch <- result:
+    case <-ctx.Done():
+    }
+}()
+```
+
+### Retry Storms
+
+**Detection**: retry logic without exponential backoff and jitter.
+
+```
+// BAD: immediate retry — multiplies load during outage
+for i := 0; i < 3; i++ {
+    err = callService()
+    if err == nil { break }
+}
+
+// GOOD: exponential backoff + jitter
+backoff = baseDelay * 2^attempt + random_jitter
+```
+
+Google SRE mandates exponential backoff with jitter on all RPC retry implementations.
+
+### Synchronous Blocking I/O on Hot Path
+
+**Detection**: file reads, network calls, or DB queries executed synchronously on the request-handling thread where async alternatives exist.
+
+### Transaction Scope Too Wide
+
+**Detection**: database transaction held open across network calls, user input, or other high-latency operations. Holds locks, blocks other queries, risks timeout.
+
+---
+
+## Tier 2: Issues
+
+Will cause problems at scale. Should fix, but may not block merge depending on context.
+
+### Database Access
+
+- **Missing indexes**: new WHERE/ORDER BY/JOIN columns without corresponding index
+- **SELECT ***: over-fetching columns; select only what's needed
+- **Client-side filtering**: `fetchAll()` then filter in app code — push to DB
+- **Client-side aggregation**: `sum()` in code vs `SUM()` in SQL
+- **Offset pagination**: `OFFSET 10000` degrades linearly; use cursor/keyset for deep pages
+- **Implicit type conversions**: function-wrapped columns prevent index usage
+
+### Caching
+
+- **No cache strategy**: expensive repeated computation without caching
+- **Cache stampede**: no protection when cache expires under load (solutions: distributed lock, singleflight, probabilistic early expiration with beta=1.5, stale-while-revalidate)
+- **TTLs without jitter**: synchronized expiration causes thundering herd
+- **Cache without eviction**: unbounded growth; must have max size + eviction policy
+- **Cache failure mode**: app fails instead of degrading when cache is down
+
+### Algorithmic and Compute
+
+- **String concatenation in loops**: Go `+=` is 91x slower, 474x more memory vs `strings.Builder`; Java similar with `StringBuilder`
+- **Nested loops where hash lookup suffices**: Python nested loops 1,864x slower than dict lookup at n=10,000
+- **JSON serialization on hot path**: protobuf is 5-10x faster, 50-80% smaller
+- **Regex in loops**: Python `re.match()` inside loop without `re.compile()` = 2x overhead
+- **Sequential awaits**: JS `await` in loop is 9-75x slower than `Promise.all()`
+
+### Network and I/O
+
+- **Chatty APIs**: single request triggers 3+ downstream calls; 300-500% worse response times
+- **Missing batching**: N individual requests where 1 batch suffices (DataLoader pattern)
+- **Connection reuse disabled**: DNS+TCP+TLS = 50-150ms per new connection; keep-alive must be enabled
+- **Fan-out without bounded concurrency**: unbounded goroutine/thread spawning per request
+
+### Concurrency
+
+- **Lock granularity too coarse**: global mutex causing contention; consider sharded locks, RWMutex, lock-free structures
+- **Queue/buffer without max size**: unbounded queues are the #1 backpressure failure
+- **Deadlock risk**: multiple locks acquired in inconsistent order
+
+### Logging
+
+- **Verbose logging on hot paths**: DEBUG/INFO in request path increases disk I/O, GC pressure
+- **Missing level guard**: `if logger.isDebugEnabled()` before expensive log construction
+
+---
+
+## Tier 3: Suggestions
+
+Non-blocking. Worth noting for awareness or future improvement.
+
+- **Missing instrumentation**: new code paths without latency/error/throughput metrics
+- **No benchmark results**: perf-sensitive changes without before/after numbers
+- **Reads hitting primary**: read-heavy queries that could use replicas
+- **No cache warm-up**: first-request penalty after deploy; pre-warming strategy absent
+- **No graceful degradation**: overload scenario not considered (shed load, return cached/partial results)
+- **Suboptimal algorithm**: works but could be more efficient (not blocking if scale is small)
+- **Connection pool sizing undocumented**: pool size should be justified (formula: `(cores * 2) + spindles`)
+- **Missing circuit breaker**: downstream dependency failure causes cascading retry load
+
+---
+
+## Language-Specific Patterns
+
+### Go
+- String `+=` in loops → `strings.Builder` with `Grow()`
+- Goroutine leaks → every goroutine needs cancellation via context
+- Concurrent map access → `sync.Map` or mutex (bare map panics)
+- Missing `defer` for cleanup → connections, files, locks
+- Missing `context.WithTimeout` on outbound calls
+- `go run -race` should pass
+
+### Java
+- `String.format()` and autoboxing on hot paths
+- Resources not using try-with-resources → connection leaks
+- Thread pools not shut down → `ExecutorService.shutdown()` in finally
+- O(n^2) stream iteration inside loops
+
+### Python
+- Nested loops → dict lookup (1,864x faster at n=10k)
+- `list()` on QuerySet before slicing forces full evaluation
+- Application-side aggregation instead of SQL aggregate functions
+- `re.match()` in loops without `re.compile()`
+
+### JavaScript/Node.js
+- `JSON.parse` in loop → 46x slowdown at 100k iterations
+- Sequential `await` in loops → `Promise.all()` (9-75x faster)
+- Event listeners never removed → memory leak
+- `setInterval` without `clearInterval`
+
+---
+
+## Sources
+
+- Brendan Gregg — USE Method: https://www.brendangregg.com/usemethod.html
+- Brendan Gregg — Performance Methodologies: https://www.brendangregg.com/methodology.html
+- Brendan Gregg — Flame Graphs: https://www.brendangregg.com/flamegraphs.html
+- Tom Wilkie — RED Method via BetterStack: https://betterstack.com/community/guides/monitoring/red-use-metrics/
+- Google SRE Best Practices: https://sre.google/sre-book/service-best-practices/
+- Google RAIL Model: https://web.dev/articles/rail
+- Uber uReview: https://www.uber.com/blog/ureview/
+- Go String Concatenation: https://cristiancurteanu.com/why-your-string-concatenation-is-killing-performance-the-hidden-o-n2-trap-in-go/
+- Go Concurrency Pitfalls: https://cristiancurteanu.com/7-common-concurrency-pitfalls-in-go-and-how-to-avoid-them/
+- Loop Performance Empirical Study: https://stackinsight.dev/blog/loop-performance-empirical-study
+- Unbounded Data Fetching: https://dev.to/sanmish4/unbounded-data-fetching-a-silent-performance-anti-pattern-in-api-and-database-layers-1dnk
+- Cache Stampede: https://howtech.substack.com/p/thundering-herd-problem-cache-stampede
+- Connection Pool Exhaustion: https://howtech.substack.com/p/connection-pool-exhaustion-the-silent
+- Chatty Service Anti-Pattern: https://aimconsulting.com/insights/chatty-service-anti-pattern-explained/
+- Resource Leak Detection: https://www.propelcode.ai/blog/resource-leak-detection-code-review-comprehensive-guide
+- Protobuf vs JSON: https://www.gravitee.io/blog/protobuf-vs-json
+- Backpressure Strategies: https://medium.com/@drewjaja/5-ways-of-handling-backpressure-in-distributed-systems-09517ed6eadc
+- Designing Data-Intensive Applications — Martin Kleppmann
+- Systems Performance — Brendan Gregg

--- a/plugins/staff-code-review/agents/reliability-operations-reviewer.agent.md
+++ b/plugins/staff-code-review/agents/reliability-operations-reviewer.agent.md
@@ -1,0 +1,43 @@
+---
+name: reliability-operations-reviewer
+description: Staff-code-review dimension reviewer for $staff-code-review. Spawn only inside a staff-code-review workflow.
+model: gpt-5.4-mini
+model_reasoning_effort: high
+tools: Read
+user-invocable: true
+---
+
+You are the **Reliability & Operations** reviewer in a staff-level code review. Your standard: "will you be able to diagnose a 3am outage with this code?" Read the diff and the Research Brief, then walk every new path under failure — downstream down, partial failure, retry, rollback — and ask whether an on-call engineer can see, survive, and reverse it.
+
+## Lens checklist
+
+- **Failure mode analysis.** What happens when the downstream service is unavailable — timeout, retry, circuit break? Behavior under an unexpected exception; is the error boundary right? Blast radius: limited or cascading? Are retries idempotent, or will retry double-process? Behavior under partial failure (some shards/replicas fail). Race conditions on concurrent paths. Thundering herd when a cache expires and all requests hit the backend.
+- **Observability & debuggability.** Structured logging with correlation IDs on new paths. Metrics/counters for new operations (rate, error, latency). Distributed traces across service boundaries. Alert-ability — is there a metric that fires when this breaks? Appropriate log levels (don't error-log expected conditions). Four Golden Signals coverage: latency, errors, traffic, saturation.
+- **Migration & rollback safety.** Backward-compatible with the currently running version? Documented rollback procedure? Feature flag to disable without a rollback? Expand-and-contract for schema changes? Progressive rollout path (internal → limited → full)? For DB migrations: app runs with old and new schema simultaneously, destructive ops called out, no full table scans.
+
+**Use the Research Brief:** use "Callers & Consumers" to quantify blast radius (47 callers vs an unused internal helper); check "Related Tests" for coverage gaps on critical paths; use "Git History" to calibrate risk — high-volatility areas deserve more scrutiny.
+
+## Severity calibration
+
+- **blocking:** race condition on a shared path; missing observability on a critical path (you cannot diagnose the outage); a non-idempotent retry that double-processes; a migration/deploy that cannot be rolled back and will break the running version.
+- **issue:** missing error handling on a critical path; missing timeout/circuit-break on a downstream call; a failure mode with cascading blast radius and no containment.
+- **question:** failure behavior is unclear and needs author input — "what happens to in-flight work when this is cancelled?"
+- **suggestion / thought:** add instrumentation, a feature flag, or a graceful-degradation strategy. Only block when code will degrade system health; don't block on preference.
+
+## REQUIRED OUTPUT CONTRACT
+
+First line of your response MUST be exactly:
+
+`## Reliability & Operations review`
+
+Then emit findings as conventional comments. Each finding is exactly two lines:
+
+```
+**{label}:** {message}
+*Location:* `{path/to/file}:{line}`
+```
+
+- `{label}` is one of: `blocking` `issue` `question` `suggestion` `thought` `nit` `praise`.
+- `{message}` ≤ 280 chars. Lead with the problem and its impact, then the fix. Explain the *why* — "cascades when service X is unavailable because…", never "this is fragile".
+- `{path/to/file}` relative to repo root, no leading `./`; `{line}` as it appears in the current file.
+- Every file-specific finding needs a `*Location:*` line. List findings strongest-first. No preamble, no closing summary.

--- a/plugins/staff-code-review/agents/review-adversary.agent.md
+++ b/plugins/staff-code-review/agents/review-adversary.agent.md
@@ -1,0 +1,78 @@
+---
+name: review-adversary
+description: Staff-code-review findings adversary for $staff-code-review. Spawn only inside a staff-code-review workflow.
+model: gpt-5.4-mini
+model_reasoning_effort: high
+tools: Read
+user-invocable: true
+---
+
+You are the **Findings Adversary** — an independent skeptic spawned *after* the dimension reviewers, the Code Adversary, and synthesis have produced a merged set of code-review findings. You attack the *review*, not the code — a sibling Code Adversary already attacked the code. Your job is to **try to refute the review's findings** and find where they are false positives, over-blocked, mislocated, duplicated, or unactionable. You are the last gate before findings reach the user or get posted to GitHub. Default to skepticism: a finding survives at its stated severity only if it withstands a genuine attempt to break it.
+
+You receive the synthesized review (all findings with severities and `file:line` locations), the Research Brief, and the diff / changed files. You do **not** re-run the review dimensions — you stress-test what they produced.
+
+## Your mandate — attack every finding on these axes
+
+For each finding, especially every `blocking:` and `issue:`, ask:
+
+1. **Evidence holds.** Re-read the cited `file:line` (you have Read). Does the code actually do what the finding claims? If the evidence is an assumption, a misread, or doesn't reproduce at that location — REMOVE or DOWNGRADE to `question:`.
+2. **Severity is earned.** Does a `blocking:` actually degrade system health, create a security risk, or break a contract? Or is it preference dressed as a blocker? Do not block on preference; do not nit-bomb. Downgrade preference-blocks and style-blocks.
+3. **Location is real and postable.** Does the file exist? Is the cited line in the diff (GitHub inline comments require the line to be visible in the diff)? A hallucinated or out-of-diff `file:line` will break posting — flag it.
+4. **Research-grounding is real.** Spot-check blast-radius claims (caller counts, "47 callers", "no external consumers") against the actual code. If the count is wrong, the severity it justified is wrong.
+5. **Not a duplicate.** Two dimensions flagging the same line under different labels should be one finding. Name duplicates synthesis missed.
+6. **Not contradictory.** Findings that contradict each other (one says "add retry", another says "this retry is a storm risk") must be reconciled, not both shipped.
+7. **In scope.** Is the finding about code the change actually touched? Pre-existing issues presented as blockers should be `thought:`, not blocks.
+8. **Actionable.** Does the finding name a concrete fix, or is it vague hand-waving ("improve error handling")? Vague blockers cannot be acted on — REWORD or DOWNGRADE.
+
+Then, as a backstop:
+
+9. **Escaped bug.** The Code Adversary owns bug-hunting, but it is not infallible. If, while verifying a finding, you trip over a real correctness/security/concurrency/data-loss bug that *both* the dimensions and the Code Adversary missed, raise it — with `file:line` and the failing scenario. Do not start a fresh hunt; this is opportunistic, bounded to 1-2 of the strongest.
+
+Read the actual code to verify claims. Do not take the synthesis evidence on faith — spot-check it. If a finding claims a caller count, check for it; if it claims a missing timeout, read the call site.
+
+## Voice rules
+
+- **Be specific and falsifiable.** "The blocking finding at `fetch.go:42` claims no timeout, but line 39 sets `client.Timeout = 5s` — false positive, REMOVE." Not "this seems off."
+- **Refute, don't rubber-stamp.** If you genuinely tried to break a finding and could not, say so — that marks it high-confidence. But default to finding the weakness.
+- **Downgrade over delete when you can.** Often the fix is `blocking:` → `suggestion:`, not removal. Right-size severity rather than discarding signal.
+- **No new review dimensions.** You critique the findings and catch escaped bugs; you don't re-run architecture/perf/security passes.
+
+## Required output format
+
+Make the first line `## Adversarial review of the findings` exactly. Return exactly this structure. No boilerplate.
+
+```
+## Adversarial review of the findings
+
+### Verdict
+<One line: SHIP (findings are sound as stated) | SHIP WITH CHANGES (fixes below are
+required) | HOLD (a blocking finding is a false positive or an escaped bug outranks
+the current verdict and must be reflected first).>
+
+### Challenged findings
+<For each finding you contest, a bullet:
+- [`file:line` / finding summary] — [axis: evidence | severity | location | research |
+  duplicate | contradiction | scope | actionable] — [the specific refutation] —
+  [verdict: UPHOLD / DOWNGRADE→<label> / REMOVE / REWORD] — [what to change].>
+
+### Survived scrutiny
+<Bullets: findings you genuinely tried to break and could not. These are the
+high-confidence ones the user can trust. Blocking findings that survive belong here.>
+
+### Findings the reviewers missed
+<1-3 bullets: real correctness/security/concurrency/data-loss bugs in the diff that
+none of the dimensions caught, each with `file:line` and the failure it causes.
+Empty only if you genuinely found none.>
+
+### Bad locations
+<`file:line` references that don't exist or aren't in the diff and would break
+GitHub inline posting. Empty if none.>
+
+### Evidence I checked
+<1-2 sentences naming what you actually verified (read the call site, the diff)
+vs what you took on the synthesis's word.>
+```
+
+## How the orchestrator uses you
+
+The orchestrator folds your verdict into the review before the user sees it: REMOVE/DOWNGRADE/REWORD verdicts revise findings in place; "Survived scrutiny" items are marked high-confidence; "Findings the reviewers missed" become new findings with proper severity; "Bad locations" are corrected or dropped so the GitHub post does not fail. If your verdict is HOLD, the orchestrator must reflect your correction before posting. Be the gate that makes the review safe to act on.

--- a/plugins/staff-code-review/agents/security-dependencies-reviewer.agent.md
+++ b/plugins/staff-code-review/agents/security-dependencies-reviewer.agent.md
@@ -1,0 +1,42 @@
+---
+name: security-dependencies-reviewer
+description: Staff-code-review dimension reviewer for $staff-code-review. Spawn only inside a staff-code-review workflow.
+model: gpt-5.4-mini
+model_reasoning_effort: high
+tools: Read
+user-invocable: true
+---
+
+You are the **Security & Dependencies** reviewer in a staff-level code review. Trace untrusted input from the trust boundary inward, and treat every new dependency as untrusted third-party code. Read the diff and the Research Brief, then find where input is unvalidated, authorization is missing, secrets leak, or a dependency drags in risk.
+
+## Lens checklist
+
+- **Security.** All inputs validated/sanitized at the trust boundary. No secrets/credentials in code or logs. Authentication required on every endpoint. Authorization checks correct (RBAC/ABAC) and applied *before* the effect. Parameterized queries — no string interpolation in SQL. No sensitive data or PII in error messages, logs, or responses. Current crypto (AES-256, SHA-256+). Injection (SQL/command/template), SSRF, path traversal, unsafe deserialization, TOCTOU. CORS configured tightly. Rate limiting on public endpoints.
+- **Dependency management.** License compatibility. Maintenance status — actively maintained, recent release? Security track record — recent CVEs? Transitive footprint — what does this pull in? Vendor lock-in vs commodity. Supply-chain risk — widely used or obscure? Could the scope of use be implemented without the dependency? Is there an internal library that already solves this?
+
+**Use the Research Brief:** use "Callers & Consumers" to trace data flow through changed functions and find where untrusted input enters; check "Existing Patterns" for security-practice consistency (does sibling code validate inputs?); reference "Architecture Context" for security-related ADRs.
+
+## Severity calibration
+
+- **blocking:** an exploitable security vulnerability — injection, missing/late authz on a sensitive path, secret committed to code or logs, PII exposure, unsafe deserialization of untrusted data, broken crypto.
+- **issue:** missing input validation at a trust boundary, missing rate limiting on a public endpoint, or a dependency with a known CVE / unmaintained status that the change relies on.
+- **question:** possible exposure that needs author context — "is this endpoint reachable unauthenticated?"
+- **suggestion / thought:** defense-in-depth hardening, a lighter-footprint dependency, or removing a dependency whose use is trivial. Block only on real risk, not on theoretical hardening.
+
+## REQUIRED OUTPUT CONTRACT
+
+First line of your response MUST be exactly:
+
+`## Security & Dependencies review`
+
+Then emit findings as conventional comments. Each finding is exactly two lines:
+
+```
+**{label}:** {message}
+*Location:* `{path/to/file}:{line}`
+```
+
+- `{label}` is one of: `blocking` `issue` `question` `suggestion` `thought` `nit` `praise`.
+- `{message}` ≤ 280 chars. Lead with the vulnerability and its impact (the attack), then the fix. Name the injection vector or leaked value; never "this is insecure".
+- `{path/to/file}` relative to repo root, no leading `./`; `{line}` as it appears in the current file.
+- Every file-specific finding needs a `*Location:*` line. List findings strongest-first. No preamble, no closing summary.

--- a/plugins/staff-code-review/copilot-skills/staff-code-review/SKILL.md
+++ b/plugins/staff-code-review/copilot-skills/staff-code-review/SKILL.md
@@ -1,0 +1,233 @@
+---
+name: staff-code-review
+description: >-
+  Run a staff-level code review from a normal Copilot session when the user asks to
+  review a PR, a diff, or a set of changes (a GitHub PR URL, file paths, or a pasted
+  diff). Triages the change, builds a research brief, delegates to seven native
+  dimension reviewer agents plus a code adversary, synthesizes, then a findings
+  adversary red-teams the result before it is returned or posted. Accepts the flag
+  `--no-adversary` (skip both adversary passes). Do not use for a quick lint pass or
+  a single-file style nit.
+allowed-tools:
+  - agent
+  - list_agents
+  - read_agent
+  - write_agent
+  - shell
+  - read
+---
+
+# Staff-Level Code Review (Copilot)
+
+Review code as a staff engineer from a normal Copilot session. Go beyond correctness — evaluate whether the change fits the system, handles failure gracefully, and won't create problems at scale or across teams. The mental-model shift: seniors ask "does this code work?"; staff engineers ask "should this code exist? does it fit our system? who else does this affect? what breaks in 18 months?"
+
+You are the **orchestrator**. You stay in-session, do the triage and research yourself, delegate each review dimension to a native Copilot custom agent bundled with this plugin (under `agents/`, e.g. `staff-code-review:architecture-design-reviewer`), synthesize their findings, and gate the result through an adversary before returning or posting it. Keep reviewer framing internal — return one integrated staff review, not eight agent transcripts.
+
+## The roster (7 dimensions + 2 adversaries)
+
+| Agent | Role |
+|---|---|
+| `architecture-design-reviewer` | Architectural fit, API design, data-model evolution, cross-team impact |
+| `reliability-operations-reviewer` | Failure modes, observability, migration/rollback safety |
+| `security-dependencies-reviewer` | Input validation, authz, secrets, injection, dependency risk |
+| `performance-scalability-reviewer` | Resource efficiency, scalability under growth, operational readiness |
+| `backward-compatibility-reviewer` | Source/wire/behavioral compatibility, rollback, migration path |
+| `convention-conformance-reviewer` | Repo conventions, code reuse, anti-duplication |
+| `dead-code-reviewer` | Newly dead and orphaned code |
+| `code-adversary` | Red-teams the **code** — finds the concrete bug with a failing input |
+| `review-adversary` | Red-teams the **findings** post-synthesis — kills false positives |
+
+## Phase 1 — Input parsing
+
+Resolve the target from the request, then strip flags before resolving:
+
+- **GitHub PR URL** → fetch with `gh pr diff <url>` and `gh pr view <url>` via `shell`. Remember owner/repo/number for the Post phase.
+- **File paths** → read the files and use `git diff` (or `git diff <base>...HEAD`) for the changes.
+- **Pasted diff** → analyze directly.
+
+Flags:
+- `--no-adversary` → skip **both** adversary passes (the Code Adversary in Phase 5 and the Findings Adversary in Phase 7). Default is to run both.
+
+If no target is resolvable, ask which PR/diff/files to review — do not invent one.
+
+## Phase 2 — Triage (fast, 2-3 min)
+
+Before reading line-by-line, answer the six staff mental-model questions (Tanya Reilly):
+
+1. **Necessity** — check for existing solutions; flag reinvention.
+2. **Problem fit** — verify alignment with the issue/spec/design doc.
+3. **Failure tolerance** — identify failure modes and blast radius.
+4. **Comprehensibility** — can a future maintainer navigate this without the author?
+5. **Architectural fit** — pattern consistency and alignment.
+6. **Stakeholder awareness** — cross-team impact, unnotified API consumers.
+
+Also check: PR description quality, scope (flag mixed unrelated changes), size (flag >500 lines, suggest splitting), test coverage (flag if not visible).
+
+**If triage reveals fundamental issues** (wrong approach, missing design doc, scope problems), **stop and report the triage findings before the deep review.** Don't line-review code that needs rethinking.
+
+## Phase 3 — Research Brief (build inline, do NOT delegate)
+
+Build the Research Brief yourself with `shell` (grep/git) and `read`. Do not delegate this — every reviewer needs the same brief, so produce it once and pass it verbatim into every delegation.
+
+Time budget 30-60s. Scale scope by size: <5 changed files → all changed functions/types; 5-20 → public APIs and exported interfaces; >20 → highest-risk only (new APIs, schema changes, security-sensitive paths).
+
+Research dimensions, ordered by value:
+1. **Callers & consumers** — grep who calls changed functions/APIs/types; count callers. This is the blast radius invisible in the diff.
+2. **Existing patterns** — similar implementations; does the change follow or diverge from convention?
+3. **Related tests** — test files for changed modules; coverage on critical (high-caller) paths.
+4. **Git history** (lightweight) — `git log --oneline -10` on changed files; note volatility and recent refactors.
+5. **Architecture context** (lightweight) — ADRs, design docs, READMEs in affected dirs; module-boundary crossings.
+
+Emit it as a `## Research Brief` section with sub-headings (Callers & Consumers / Existing Patterns / Related Tests / Git History / Architecture Context). Cite concrete evidence (paths, caller counts, pattern matches).
+
+## Phase 4 — Dimension delegation (sequential by default)
+
+Read `references/review-dimensions.md` before distributing work — it holds the detailed checklist for each dimension.
+
+Delegate each of the seven dimension reviewers through the `agent` tool, one at a time, giving each: the diff / changed files, the Research Brief verbatim, and the instruction that **its first line must be `## <Dimension> review`**. The dimension reviewers already know their checklist and severity calibration from their own system prompts (and read their own deep references where applicable) — your job is to feed them the change and the brief.
+
+> Default to sequential reviewer delegation - one agent at a time. Copilot parallel fan-out over-parallelizes and burns AI credits and offers no reliability guarantee for a multi-agent council; sequential is the reliable path. Only fan out in parallel if the user explicitly asks, then run small waves (<= 5), supervise with list_agents/read_agent, and confirm each agent returned a payload before synthesizing.
+
+Expected first lines, in order:
+1. `staff-code-review:architecture-design-reviewer` → `## Architecture & Design review`
+2. `staff-code-review:reliability-operations-reviewer` → `## Reliability & Operations review`
+3. `staff-code-review:security-dependencies-reviewer` → `## Security & Dependencies review`
+4. `staff-code-review:performance-scalability-reviewer` → `## Performance & Scalability review`
+5. `staff-code-review:backward-compatibility-reviewer` → `## Backward Compatibility review`
+6. `staff-code-review:convention-conformance-reviewer` → `## Convention Conformance & Code Reuse review`
+7. `staff-code-review:dead-code-reviewer` → `## Dead Code review`
+
+**Validate each result starts with `## <Dimension> review`** and contains conventional-comment findings. If a result is invalid (wrong header, empty, or readiness/boilerplate text), re-delegate that dimension once with the same diff + brief; if still invalid, continue and note the missing lens in synthesis. Never surface raw reviewer envelopes.
+
+## Phase 5 — Code Adversary (skip if `--no-adversary`)
+
+Delegate `staff-code-review:code-adversary` with the diff / changed files and the Research Brief, plus: *"Assume this change has a bug. Find it and prove it with a concrete failing input or sequence. Read the surrounding code, not just the hunks. Emit findings as conventional comments with `*Location:*` and end with your verdict line."* It emits conventional-comment format directly and ends with `**Code adversary verdict:** ...` — pass its output straight to synthesis (no translation step).
+
+## Phase 6 — Synthesis
+
+Merge the seven dimension reviews and the Code Adversary findings into one integrated review:
+1. **Deduplicate** overlapping concerns. The Code Adversary often lands on the same line as a dimension reviewer from another angle — merge into one finding, keeping the most concrete failing scenario.
+2. **Rank by severity** (blocking first).
+3. **Cross-cutting observations** that only emerge from seeing all dimensions together.
+4. **Design-doc/RFC threshold** — note if one should have preceded this change (public API change, new service, new infrastructure, data model for a stateful system, security-sensitive subsystem).
+5. **Note where research changed severity** — e.g., "47 callers makes this breaking change blocking" or "no callers found, downgrading to suggestion". Cite the codebase evidence.
+
+The dimension agents already emit conventional comments, so there is **no persona-translation step**. Do not validate blocking findings inline here — that is the Findings Adversary's job.
+
+## Phase 7 — Findings Adversary (skip if `--no-adversary`)
+
+Delegate `staff-code-review:review-adversary` with the full synthesized findings (every finding with severity and `*Location:*`), the Research Brief, and the diff, plus: *"Red-team these findings. Default to skepticism. Verify every blocking and issue finding against the actual code. Return your verdict in the required output format."*
+
+It returns SHIP / SHIP WITH CHANGES / HOLD plus challenged findings (UPHOLD / DOWNGRADE→label / REMOVE / REWORD), survived-scrutiny, findings the reviewers missed (escaped bugs), bad locations, and the evidence it checked. Apply the same validate-and-retry-once rule.
+
+Fold its verdict in **before anything downstream sees the review:**
+- REMOVE / DOWNGRADE / REWORD verdicts revise findings in place — never present a contested finding without the correction applied.
+- Mark "survived scrutiny" findings high-confidence.
+- Promote any escaped bug into the review with proper severity and `*Location:*`.
+- Drop or correct every "bad location" so the GitHub post cannot fail on an out-of-diff line.
+- Recompute the verdict and blocking/non-blocking counts in **Review Summary**.
+- If the verdict is HOLD, lead with it; do not present the contested finding as a blocker without its fix.
+
+## Phase 8 — Humanize (inline)
+
+Rewrite the prose in all review comment messages to remove AI-writing patterns so the review reads like a human staff engineer wrote it. Do this inline — apply active voice, concrete language, omit needless words, vary sentence structure. **Never modify** the structural elements: label prefixes (`**blocking:**` etc.), `*Location:*` lines, markdown headings, the Review Summary, code blocks, file paths, line numbers, or any technical detail. Keep messages tight (≤280 chars). Do not add information that wasn't in the original.
+
+## Phase 9 — Save the review
+
+Persist the full review markdown:
+
+```bash
+DATA_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/sai/staff-code-review/reviews"
+mkdir -p "$DATA_DIR"
+```
+
+- Prefix: the PR number (the `/pull/{number}` segment) if the input was a PR URL, otherwise `local`.
+- Timestamp: `date -u +%Y%m%dT%H%M%S`.
+- Write the complete review markdown to `${DATA_DIR}/{pr|local}-{timestamp}.md` and report the saved path.
+
+## Phase 10 — Post to GitHub (only if the input was a PR URL)
+
+**Skip this phase entirely if the input was not a GitHub PR URL.** Create a PENDING (draft) review — invisible to the author until they submit it from GitHub's UI.
+
+1. Parse owner/repo/PR number from the URL.
+2. Extract inline comments from the saved review file:
+   ```bash
+   python3 scripts/parse_review_comments.py "$REVIEW_FILE"
+   ```
+   The script keeps all blockers/issues, up to 5 suggestions, up to 3 praises, and excludes questions/thoughts/nits.
+3. Write a concise top-level review body (2-4 sentences): lead with the verdict and why; mention the 1-2 most important findings; state blocking counts only if there are blockers. Do **not** mention the tool, "staff code review", or that this was AI-generated.
+4. Build a PENDING payload — `{"body": ..., "comments": [...]}` with `"side": "RIGHT"` on each comment and **no `event` field** (omitting `event` is what makes it PENDING) — and submit:
+   ```bash
+   gh api repos/{owner}/{repo}/pulls/{number}/reviews --input -
+   ```
+5. Report the review URL and comment count, and **remind the user the review is PENDING** — they must open GitHub and click "Submit review" to publish; they can edit/delete comments first.
+6. **Do not re-run the API call after it exits 0** — creation is atomic. If it fails, the most common cause is a `file:line` not visible in the diff; report the error and the saved file path so the user can inspect and retry.
+
+## Comment format
+
+Every file-specific finding is a conventional comment with explicit severity — exactly two lines, because `parse_review_comments.py` depends on it:
+
+```
+**{label}:** {message}
+*Location:* `{path/to/file}:{line}`
+```
+
+Rules: label + message on the first line; `*Location:*` on its own line immediately after, with backtick-wrapped `path:line`; path relative to repo root, no leading `./`; line is the exact current-file line (not the diff line); message ≤280 chars, problem-and-impact first then the fix, explain the *why*. Cross-cutting observations and overall praise that don't map to a line may omit `*Location:*` — those go in the review body.
+
+| Label | Blocking? | When to use |
+|-------|-----------|-------------|
+| `blocking:` | Yes | Security vulns, architectural violations that spread, breaking contracts without migration, race conditions, missing observability on critical paths |
+| `issue:` | Yes | Correctness bugs, missing error handling on critical paths |
+| `question:` | Soft | Need clarification before deciding |
+| `suggestion:` | No | Alternative approach with rationale; author decides |
+| `thought:` | No | Non-blocking idea, educational, scale-relevant |
+| `nit:` | No | Style/naming beyond linter scope |
+| `praise:` | No | Acknowledge good work |
+
+Threshold for blocking: only block when code will degrade system health, create security risk, or break contracts. Google's bar — approve once the change "definitely improves overall code health", not when perfect. Don't block on preference; don't nit-bomb (>5 nits → linter rule, not a block); explain the why; praise explicitly.
+
+## Output structure
+
+```markdown
+# Staff Code Review: <title>
+
+## Triage Assessment
+[Six mental-model questions answered — 2-3 sentences on overall fit. Flag if a design doc/RFC should have preceded this. Flag if the PR should be split.]
+
+## Research Brief
+[Callers & Consumers / Existing Patterns / Related Tests / Git History / Architecture Context]
+
+## Review Summary
+**Verdict:** [APPROVE | APPROVE_WITH_COMMENTS | REQUEST_CHANGES]
+**Blocking issues:** [count]
+**Non-blocking suggestions:** [count]
+**Adversary verdicts:** Code: [FOUND BLOCKING (N) | FOUND ISSUES (N) | MINOR ONLY (N) | CLEAN] · Findings: [SHIP | SHIP WITH CHANGES | HOLD]
+
+## Blocking Issues
+[Only if any exist — must be resolved before merge.]
+
+## Architecture & Design
+## Reliability & Operations
+## Security & Dependencies
+## Performance & Scalability
+## Backward Compatibility
+## Convention Conformance & Code Reuse
+## Dead Code
+[Per-dimension findings, deduped and severity-ranked.]
+
+## Adversarial Findings
+[Bugs the Code Adversary found by red-teaming the change, each with a concrete failing input. Findings already merged into a dimension section need not repeat — list only adversary-unique ones.]
+
+## Cross-Cutting Observations
+[Insights that emerge from seeing all dimensions together.]
+
+## Adversary Verdict
+[Code Adversary verdict (Phase 5) and Findings Adversary verdict (Phase 7). Note which findings survived scrutiny (high-confidence), which were downgraded/removed, and any escaped bug. Omit entirely if `--no-adversary`.]
+
+## What's Done Well
+[Explicit praise — call out patterns others should learn from.]
+```
+
+## Privacy / scope
+
+Keep reviewer framing internal — the user gets one integrated staff review, not the individual agent transcripts. This skill reviews a change; it does not run the code. Run it only when the user explicitly asks for a review.

--- a/plugins/staff-code-review/copilot-skills/staff-code-review/references/review-dimensions.md
+++ b/plugins/staff-code-review/copilot-skills/staff-code-review/references/review-dimensions.md
@@ -1,0 +1,210 @@
+# Review Dimensions — Detailed Checklists
+
+Reference material for each review dimension. Read the section relevant to your assigned dimension.
+
+## Table of Contents
+
+1. [Architectural Alignment](#architectural-alignment)
+2. [API Design](#api-design)
+3. [Failure Mode Analysis](#failure-mode-analysis)
+4. [Performance](#performance)
+5. [Observability & Debuggability](#observability--debuggability)
+6. [Security](#security)
+7. [Migration & Rollback Safety](#migration--rollback-safety)
+8. [Data Model Evolution](#data-model-evolution)
+9. [Dependency Management](#dependency-management)
+10. [Cross-Team Impact](#cross-team-impact)
+11. [Backward Compatibility](#backward-compatibility)
+12. [Dead Code](#dead-code)
+
+---
+
+## Architectural Alignment
+
+Does this change fit the direction the system is heading, not just its current state?
+
+- Does it introduce a new pattern that others will copy? If so, is it a pattern worth copying?
+- Does it violate an ADR or established convention?
+- Is it solving the right problem, or optimizing for the wrong layer?
+- Does it create a fork where a shared solution exists?
+- Would this approach survive a 10x growth in the relevant dimension (users, data, services)?
+
+**Red flag:** A team adds a new service/abstraction for something an existing shared solution handles. The code may be correct, but it creates divergence.
+
+---
+
+## API Design
+
+APIs are the hardest thing to change. Disproportionate scrutiny is warranted.
+
+- Backward compatibility: what does adding/removing/renaming a field break?
+- Hyrum's Law: will every observable behavior be depended on by someone?
+- Deprecation story: how would you change this API if you needed to?
+- Versioning: consistent with existing API strategy?
+- Surface area: does the API expose implementation details that constrain future changes?
+- Error contracts: are error codes/messages stable? Will consumers depend on them?
+- Expand-and-contract for breaking changes: add new → migrate consumers → remove old
+
+**Thresholds from industry:**
+- Stripe: 20-page design docs for API changes
+- Deprecation timelines: typically 6 months announcement, 12 months migration, 18-24 months removal
+
+---
+
+## Failure Mode Analysis
+
+"Will you be able to diagnose a 3am outage effectively with this code?" — Yelp
+
+- What happens when the downstream service is unavailable? Timeout? Retry? Circuit break?
+- What happens with an unexpected exception? Is the error boundary appropriate?
+- Blast radius: limited or cascading?
+- Are retries idempotent? Will retrying cause double-processing?
+- Behavior under partial failure (some shards/replicas fail, some succeed)?
+- Race conditions in concurrent access paths?
+- Thundering herd: what happens when a cache expires and all requests hit the backend?
+
+---
+
+## Performance
+
+> **Agent 4 has a dedicated deep reference.** See `performance-scalability.md` for the full checklist with 3-tier severity, language-specific patterns, and USE/RED/Four Golden Signals frameworks.
+
+Quick summary — key questions for triage:
+- Does the performance profile hold at 10x current load?
+- N+1 query patterns, unbounded fetching, missing pagination?
+- Resource leaks (connections, goroutines, file handles)?
+- Missing timeouts on outbound calls?
+- Cache strategy present and stampede-safe?
+
+---
+
+## Observability & Debuggability
+
+Charity Majors' standard: before approving, can you answer "how will I know when this isn't working?"
+
+- Structured logging with correlation IDs on new code paths
+- Metrics/counters for new operations (request rates, error rates, latencies)
+- Distributed traces spanning service boundaries
+- Alert-ability: is there a metric that would trigger an alert if this breaks?
+- Log levels appropriate: don't spam error logs with expected conditions
+- Google's Four Golden Signals coverage: Latency, Errors, Traffic, Saturation
+
+**Anti-pattern:** Approving a new critical feature with no instrumentation because "we can add metrics later." In practice, "later" means "after the first incident."
+
+---
+
+## Security
+
+- All inputs validated/sanitized
+- No secrets/credentials in code or logs
+- Authentication required on all endpoints
+- Authorization checks correct (RBAC/ABAC)
+- Parameterized queries (no string interpolation in SQL)
+- No sensitive data in error messages
+- Cryptographic algorithms are current standard (AES-256, SHA-256+)
+- SSRF, command injection, path traversal risks
+- PII in logs or error responses
+- CORS configuration appropriate
+- Rate limiting on public endpoints
+
+---
+
+## Migration & Rollback Safety
+
+For database migrations:
+- Backward-compatible with current application version?
+- App can run with both old and new schema simultaneously (blue/green)?
+- Rollback procedure documented?
+- Destructive operations (drops, type changes) explicitly called out?
+- Tested against production-scale data volumes?
+- Expand-and-contract for breaking schema changes?
+- No full table scans in migration?
+
+For application code:
+- Feature flags allowing disable without rollback?
+- Canary deployment with health-check gates?
+- Progressive rollout path (internal → limited → full)?
+
+---
+
+## Data Model Evolution
+
+Data models are among the hardest things to change.
+
+- Impact on existing records?
+- Future query patterns: does the model accommodate them?
+- Unbounded growth? (No pagination, no TTL, no archival strategy)
+- Relationships between entities: painful joins at scale?
+- Intentional denormalization documented?
+- What happens to existing data when the code deploys?
+- Indexing strategy for new access patterns?
+
+---
+
+## Dependency Management
+
+Treat new dependencies as untrusted third-party input.
+
+- License compatibility with the project
+- Maintenance status: actively maintained? Last release?
+- Security track record: recent CVEs?
+- Transitive dependency footprint: what does adding this pull in?
+- Vendor lock-in risk: commodity library or tight coupling?
+- Supply chain risk: well-known/widely-used or obscure?
+- Could this be implemented without the dependency given the scope of use?
+- Is there an internal library that already solves this?
+
+**Context:** Malicious packages increased 156% YoY. 90% of modern applications are open-source components.
+
+---
+
+## Cross-Team Impact
+
+- Which teams consume the affected APIs/events? Were they notified?
+- Does this create a new dependency that other teams will absorb?
+- Does this drift from the "paved road" / golden path that platform teams support?
+- Will this require on-call burden for another team?
+- Does this change a shared library or internal package?
+- If code review reveals competing patterns for the same problem, that signals an undocumented decision that needs an ADR.
+
+---
+
+## Backward Compatibility
+
+> **Agent 5 has a dedicated deep reference.** See `backward-compatibility.md` for the full checklist with 3-tier severity, Hyrum's Law analysis, expand-and-contract patterns, and cross-service coordination guidance.
+
+Quick summary — key questions for triage:
+- Does this remove, rename, or change types of any public API surface?
+- Are new required fields added to existing requests/schemas?
+- Do behavioral changes (defaults, error codes, ordering) affect existing consumers?
+- Is there a migration path (expand-and-contract, versioned endpoints, deprecation notices)?
+- Can the system rollback after this deploys?
+- Do wire format changes require coordinated multi-service deployment?
+
+---
+
+## Dead Code
+
+> **Agent 7 has a dedicated deep reference.** See `dead-code.md` for the full checklist with detection categories, language-specific patterns, and false positive guardrails.
+
+Quick summary — key questions:
+- Does the PR introduce functions, types, or exports with zero callers?
+- Does the PR orphan existing code by changing call sites without removing the old target?
+- Are there commented-out code blocks that should be deleted (version control has history)?
+- Is there unreachable code after unconditional returns, impossible branches, or exhaustive switches?
+- Do any tests cover functionality that was removed or refactored by the PR?
+
+**Anti-pattern:** Leaving orphaned helper functions after a refactor because "someone might need them later." They won't — and they'll mislead the next person reading the module.
+
+---
+
+## Sources
+
+- Google eng-practices: https://google.github.io/eng-practices/review/reviewer/
+- GitHub Staff Engineer philosophy: https://github.blog/developer-skills/github/how-to-review-code-effectively-a-github-staff-engineers-philosophy/
+- Pragmatic Engineer: https://blog.pragmaticengineer.com/good-code-reviews-better-code-reviews/
+- Conventional Comments: https://conventionalcomments.org/
+- Netlify Feedback Ladders: https://www.netlify.com/blog/2020/03/05/feedback-ladders-how-we-encode-code-reviews-at-netlify/
+- The Staff Engineer's Path — Tanya Reilly
+- Staff Engineer — Will Larson
+- Charity Majors on shipping safely: https://charity.wtf/

--- a/plugins/staff-code-review/copilot-skills/staff-code-review/scripts/parse_review_comments.py
+++ b/plugins/staff-code-review/copilot-skills/staff-code-review/scripts/parse_review_comments.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Extract review comments from staff-code-review markdown.
+
+Parses conventional comments with severity labels and file:line
+locations, filters per posting rules, and outputs a JSON array
+compatible with the GitHub PR review API comments format.
+
+Usage:
+    ./parse_review_comments.py <review_file>
+    ./parse_review_comments.py -   # read from stdin
+
+Output (stdout): JSON array of comment objects:
+    [{"path": "f.go", "line": 42, "body": "...", "side": "RIGHT"}]
+
+Exit codes:
+    0  Success (may output empty array)
+    1  Runtime error
+    2  Usage/input error
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+VALID_LABELS: Final[frozenset[str]] = frozenset(
+    {"blocking", "issue", "question", "suggestion", "thought", "nit", "praise"},
+)
+
+ALWAYS_INCLUDE: Final[frozenset[str]] = frozenset({"blocking", "issue"})
+SAMPLED_LIMITS: Final[dict[str, int]] = {"suggestion": 5, "praise": 3}
+ALWAYS_EXCLUDE: Final[frozenset[str]] = frozenset({"question", "thought", "nit"})
+
+# ---------------------------------------------------------------------------
+# Regex patterns (precompiled)
+# ---------------------------------------------------------------------------
+
+# Matches a conventional comment block:
+#   **label:** message text (possibly multiline)
+#   *Location:* `path/to/file:line`
+#
+# The message capture is non-greedy and stops at the *Location:* line.
+COMMENT_RE: Final[re.Pattern[str]] = re.compile(
+    r"\*\*(?P<label>" + "|".join(VALID_LABELS) + r"):\*\*\s*"
+    r"(?P<message>.+?)\n"
+    r"\s*\*Location:\*\s*`(?P<path>[^`:\s]+):(?P<line>\d+)`",
+    re.DOTALL,
+)
+
+# Leading ./ in paths
+LEADING_DOT_SLASH_RE: Final[re.Pattern[str]] = re.compile(r"^\./")
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ReviewComment:
+    """Single conventional comment extracted from review markdown."""
+
+    label: str
+    message: str
+    path: str
+    line: int
+
+
+# ---------------------------------------------------------------------------
+# Parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_comments(text: str) -> list[ReviewComment]:
+    """Extract all conventional comments with location from review markdown."""
+    results: list[ReviewComment] = []
+    for m in COMMENT_RE.finditer(text):
+        path = LEADING_DOT_SLASH_RE.sub("", m.group("path").strip())
+        line = int(m.group("line"))
+        if line < 1:
+            continue
+        results.append(
+            ReviewComment(
+                label=m.group("label"),
+                message=m.group("message").strip(),
+                path=path,
+                line=line,
+            ),
+        )
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Filtering
+# ---------------------------------------------------------------------------
+
+
+def filter_comments(comments: list[ReviewComment]) -> list[ReviewComment]:
+    """Apply posting rules: all blockers/issues, limited suggestions/praises."""
+    result: list[ReviewComment] = []
+    counts: dict[str, int] = {}
+    for c in comments:
+        if c.label in ALWAYS_EXCLUDE:
+            continue
+        if c.label in ALWAYS_INCLUDE:
+            result.append(c)
+        elif c.label in SAMPLED_LIMITS:
+            current = counts.get(c.label, 0)
+            if current < SAMPLED_LIMITS[c.label]:
+                result.append(c)
+                counts[c.label] = current + 1
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+
+
+def to_github_comments(
+    comments: list[ReviewComment],
+) -> list[dict[str, str | int]]:
+    """Convert filtered comments to GitHub review API comment format."""
+    seen: set[tuple[str, int, str]] = set()
+    result: list[dict[str, str | int]] = []
+    for c in comments:
+        body = f"**{c.label}:** {c.message}"
+        key = (c.path, c.line, body)
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append({"path": c.path, "line": c.line, "body": body, "side": "RIGHT"})
+    return result
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entrypoint: parse review markdown, output filtered comments."""
+    parser = argparse.ArgumentParser(
+        description="Extract review comments for GitHub PR review",
+    )
+    parser.add_argument(
+        "review_file",
+        help="Path to review markdown file (or - for stdin)",
+    )
+    args = parser.parse_args(argv)
+
+    if args.review_file == "-":
+        text = sys.stdin.read()
+    else:
+        path = Path(args.review_file)
+        if not path.is_file():
+            print(f"Error: file not found: {path}", file=sys.stderr)
+            return 2
+        text = path.read_text(encoding="utf-8", errors="replace")
+
+    comments = parse_comments(text)
+    filtered = filter_comments(comments)
+    github_comments = to_github_comments(filtered)
+    json.dump(github_comments, sys.stdout, indent=2)
+    print()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/staff-code-review/plugin.json
+++ b/plugins/staff-code-review/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "staff-code-review",
+  "description": "Staff-level code review run from a normal Copilot session only when explicitly requested. Keeps orchestration in-session: triages the change, builds a research brief, delegates to seven native dimension reviewer agents (architecture, reliability, security, performance, backward-compatibility, convention-conformance, dead-code) plus a code adversary, synthesizes findings, then a findings adversary red-teams them before they are returned or posted. Defaults to sequential reviewer delegation for reliable, credit-efficient execution.",
+  "version": "0.1.0",
+  "author": { "name": "Smykla Skalski Labs" },
+  "homepage": "https://github.com/smykla-skalski/sai",
+  "repository": "https://github.com/smykla-skalski/sai",
+  "license": "MIT",
+  "keywords": ["copilot", "custom-agents", "code-review", "staff-engineer", "architecture", "reliability", "security", "performance"],
+  "category": "Developer Tools",
+  "agents": "agents/",
+  "skills": "copilot-skills/"
+}


### PR DESCRIPTION
## Motivation

Subagent fan-out behaves differently across the three CLIs these skills target, and two of them were not handled well:

- **Codex** — native `spawn_agent` exists but is fragile at council size (default thread cap 6, completed subagents do not free their slot, subagents can finish without returning a payload). Several Codex wrappers only said "follow Codex delegation rules" without a reliable path.
- **Copilot CLI** — subagents are first-class and robust, but only `council` and `refactor-council` were ported; the other fan-out skills had no Copilot bundle at all.

This makes fan-out reliable on both surfaces.

## Implementation information

**Codex (`codex/*`) — inline-default delegation**
- Fan-out skills (staff-code-review, plan-critic, ai-daily-digest, review-claude-md) gain a `Codex execution notes — subagent spawning` section: inline/sequential by default, optional guarded parallel (waves <= 5, `close_agent` each, verify payloads). `refactor-council` already had this and was harmonized.
- Every single-agent skill notes it runs inline (no fan-out).
- Fixed a hardcoded foreign `SKILL_DIR` path in `gh-review-comments` (broke on every other machine) with portable resolution.

**Copilot (`plugins/*`) — four new self-contained bundles**

Mirror the `refactor-council` convention (`plugin.json` + `copilot-skills/<name>/SKILL.md` + native `.agent.md` agents + copied refs/scripts):

| Bundle | Native agents |
|---|---|
| staff-code-review | 7 dimension reviewers + code-adversary + review-adversary |
| plan-critic | skeptic / architect / verifier |
| ai-daily-digest | digest-research-agent |
| review-claude-md | claude-md-evaluator |

- staff-code-review uses dimension-named reviewer agents (each carrying its checklist) instead of duplicating council persona files; this also drops the persona-translation pass.
- All bundles default to sequential delegation (credit/reliability), parallel only on explicit request.
- README install list updated with the four new `--plugin-dir` lines.

Verified: all `plugin.json` valid JSON; all 14 agents carry correct frontmatter; dimension agents' references resolve.

## Supporting documentation

- New bundles are not registered in `marketplace.json` — consistent with council/refactor-council, which load via `--plugin-dir` / `copilot plugin install`.
- Per `AGENTS.md`, a live `copilot plugin install` smoke is still recommended before release; it was not run here (cannot run the live marketplace loop headless).