### PR TITLE
chore(staff-code-review): bump version to 1.9.1

### DIFF
--- a/claude/staff-code-review/.claude-plugin/plugin.json
+++ b/claude/staff-code-review/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "staff-code-review",
   "description": "Staff-engineer-level code review evaluating architectural alignment, system-level implications, failure modes, performance, scalability, observability, security, and cross-team impact.",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "author": {
     "name": "Smykla Skalski Labs"
   },


### PR DESCRIPTION
## Motivation

The humanize path fix (issue 54) merged into `main` without a version
bump. The Claude Code plugin manager's update check is keyed on
`plugin.json`'s `version` field, not on commit SHA, so the merged fix
never actually reached installed copies of the plugin.

> Changelog: chore(staff-code-review): bump version to 1.9.1

## Implementation information

Bump `claude/staff-code-review/.claude-plugin/plugin.json` version from
`1.9.0` to `1.9.1` (patch — bug fix only, no behavior change beyond the
already-merged fix).