### PR TITLE
feat(ship-issue): add marketplace skill

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -207,6 +207,18 @@
         "authentication": "ON_INSTALL"
       },
       "category": "Developer Tools"
+    },
+    {
+      "name": "ship-issue",
+      "source": {
+        "source": "local",
+        "path": "./plugins/ship-issue"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
     }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -193,6 +193,17 @@
       "license": "MIT",
       "category": "productivity",
       "tags": ["testing", "table-driven", "behavior-testing", "tdd", "mocking", "test-quality"]
+    },
+    {
+      "name": "ship-issue",
+      "source": "./claude/ship-issue",
+      "description": "Take a GitHub issue from implementation through adversarial review and testing, PR, CI and Copilot review, merge, and closure.",
+      "author": {
+        "name": "Smykla Skalski Labs"
+      },
+      "license": "MIT",
+      "category": "productivity",
+      "tags": ["github", "issues", "pull-request", "ci", "copilot", "automation", "shipping"]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Repository layout:
 | **review-claude-md**    | Audit and fix CLAUDE.md files using tiered binary checklist                             | `claude/review-claude-md/`    |
 | **staff-code-review**   | Staff-engineer-level code review: architecture, reliability, security, cross-team impact | `claude/staff-code-review/`   |
 | **staff-resume**        | Build and refine staff-level engineering resumes through interactive coaching           | `claude/staff-resume/`        |
+| **ship-issue**          | Ship a GitHub issue through implementation, adversarial review/testing, PR, CI, Copilot review, merge, and closure | `claude/ship-issue/` |
 | **test-writer**         | Write behavior-driven tests with table-driven patterns and minimal mocking             | `claude/test-writer/`         |
 
 Codex skills:
@@ -38,6 +39,7 @@ Codex skills:
 | **refactor-council**   | Refactoring review through 7 personas + adversary; sequential by default on Codex for reliable execution | `codex/refactor-council/` |
 | **gh-review-comments** | Manage GitHub PR review threads with bundled gh CLI scripts                      | `codex/gh-review-comments/`  |
 | **promptgen**           | Turn rough instructions into stronger prompts using the Claude promptgen source workflow | `codex/promptgen/`            |
+| **ship-issue**          | Ship a GitHub issue through implementation, review, testing, PR, CI, and merge | `codex/ship-issue/` |
 
 ## Installation
 
@@ -72,6 +74,7 @@ The equivalent non-interactive forms are `copilot plugin ...` and
 /plugin install review-claude-md@sai
 /plugin install staff-code-review@sai
 /plugin install staff-resume@sai
+/plugin install ship-issue@sai
 /plugin install test-writer@sai
 ```
 
@@ -99,6 +102,7 @@ claude --plugin-dir /path/to/sai/claude/refactor-council
 claude --plugin-dir /path/to/sai/claude/review-claude-md
 claude --plugin-dir /path/to/sai/claude/staff-code-review
 claude --plugin-dir /path/to/sai/claude/staff-resume
+claude --plugin-dir /path/to/sai/claude/ship-issue
 claude --plugin-dir /path/to/sai/claude/test-writer
 
 # Copilot CLI can load the same self-contained plugin directories directly.

--- a/claude/ship-issue/.claude-plugin/plugin.json
+++ b/claude/ship-issue/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "ship-issue",
+  "description": "Autonomously take a GitHub issue from implementation through adversarial review and testing, PR, CI and Copilot review, merge, and closure.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Smykla Skalski Labs"
+  },
+  "repository": "https://github.com/smykla-skalski/sai",
+  "license": "MIT",
+  "keywords": ["github", "issues", "pull-request", "ci", "copilot", "automation", "shipping"]
+}

--- a/claude/ship-issue/README.md
+++ b/claude/ship-issue/README.md
@@ -1,0 +1,28 @@
+# ship-issue
+
+Take one GitHub issue from URL to merged pull request autonomously: explore the repository, implement and test the change, red-team it with code review and manual testing, open a PR, address Copilot feedback, wait for green CI, merge, and close the issue.
+
+## Installation
+
+```bash
+claude plugin marketplace add smykla-skalski/sai
+claude plugin install ship-issue@sai
+```
+
+For local development:
+
+```bash
+claude --plugin-dir /path/to/sai/claude/ship-issue
+```
+
+## Usage
+
+```text
+/ship-issue https://github.com/owner/repo/issues/123
+```
+
+The skill owns the full ticket lifecycle and stops only for genuine ambiguity, branch-protection requirements, persistent review/test failures, or product decisions that cannot be recovered from the issue and repository.
+
+## License
+
+MIT

--- a/claude/ship-issue/skills/ship-issue/SKILL.md
+++ b/claude/ship-issue/skills/ship-issue/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: ship-issue
+description: End-to-end ship a GitHub issue — implement, adversarial code review via subagent, adversarial manual testing via subagent, open PR, wait for Copilot review + green CI, address feedback, merge, close issue. Use when given a GitHub issue URL and asked to implement and ship it.
+argument-hint: "<github-issue-url>"
+user-invocable: true
+allowed-tools:
+  - Agent
+  - Read
+  - Edit
+  - Write
+  - Grep
+  - Glob
+  - Bash
+---
+
+# Ship Issue
+
+Take a GitHub issue from URL to merged PR autonomously. Implement, review, manually test, open PR, wait for Copilot and CI, fix feedback, merge, and close.
+
+**Role:** Senior engineer owning the full lifecycle of one ticket.
+
+**Mode:** Autonomous. Ask no clarifying questions unless the issue is ambiguous and the repository cannot resolve it. Default to the most reasonable interpretation and ship.
+
+## Invocation
+
+```text
+/ship-issue <github-issue-url>
+```
+
+## Phase 1 — Read the issue
+
+Parse the owner, repository, and issue number from the URL, then inspect the open issue with `gh issue view` including title, body, labels, assignees, milestone, state, and comments. Stop and report if it is closed. Extract scope hints from labels and linked PRs from comments.
+
+## Phase 2 — Explore the repository
+
+- Read the root `CLAUDE.md` when present.
+- Identify the primary stack from its manifests.
+- Find the project’s lint, format, type-check, test, and build commands.
+- Locate the affected code and existing tests before editing.
+
+## Phase 3 — Branch
+
+Fetch origin, resolve the repository default branch with `gh repo view`, fast-forward it, then create:
+
+```text
+<type>/issue-<number>-<slug>
+```
+
+Infer `<type>` from the issue (`feat`, `fix`, `chore`, `docs`, `refactor`, `perf`, `test`, `ci`, `build`, `style`, or `revert`), and make `<slug>` a kebab-case, roughly 50-character title summary.
+
+## Phase 4 — Implement
+
+Work in small, focused commits and follow the repository’s established patterns. Add or extend behavior-focused tests. Before every commit run the relevant formatter, linter, type checker, build, and tests. Never use a lint/type suppression or `--no-verify`; fix the root cause.
+
+Use signed conventional commits with a required scope and a title of at most 50 characters:
+
+```text
+<type>(<scope>): <description>
+
+Refs #<number>
+```
+
+Do not add AI attribution or PR references to commit titles.
+
+## Phase 5 — Adversarial code review
+
+Before pushing, use `staff-code-review:code-adversary` when available, otherwise a general-purpose subagent, to red-team the branch. Provide the issue body, `git diff <default>...HEAD`, and changed-file list. The reviewer must assume the change is broken and identify concrete failures: unsolved acceptance criteria, edge cases, races, error handling, security/regressions, weak tests, and convention violations. Each finding must include severity, location, failing scenario, and exact fix; no praise.
+
+Apply blocker and should-fix findings, then rerun quality gates. Investigate uncertain findings; put genuinely unresolved questions in the PR body rather than silently blocking.
+
+## Phase 6 — Adversarial manual testing
+
+Spawn a fresh general-purpose tester from the current branch tip after Phase 5. The tester must derive acceptance criteria from the issue and run the real changed product surface: start a service and probe it, run the real CLI in isolated state, exercise a sandbox, or otherwise execute the strongest user-visible behavior. Automated tests, lint, build, and grep are supporting evidence only.
+
+For pure refactors, internal helpers, or documentation changes with no runnable product surface, use the strongest behavioral regression evidence available; static review or grep alone is insufficient. In the Sybra repository, invoke `sybra-test` instead of improvising the test harness.
+
+The tester must attack happy paths, boundaries, malformed input, repeated/concurrent use, and adjacent flows and finish with exactly one line:
+
+```text
+TEST_VERDICT: PASS
+```
+
+or
+
+```text
+TEST_VERDICT: FAIL
+```
+
+On FAIL, treat every reproduction as a blocker: fix it, add a regression test, rerun quality gates, and respawn the tester against the new tip. After more than three unsuccessful fixes for the same reproduction, stop and ask the user. Do not open a PR until PASS.
+
+## Phase 7 — Push and open the PR
+
+Push the branch, create a PR against the default branch, and use the conventional lead-commit title. The body must have `## Motivation`, `## Implementation information`, `Closes #<number>`, and a changelog line. Capture the PR number.
+
+Request a Copilot review when configured, using `github-copilot[bot]` and the Copilot review app fallback. Failure to request either must not fail the PR creation.
+
+## Phase 8 — Wait for Copilot and CI
+
+Poll every 5–10 minutes; do not busy-loop. On each poll inspect `gh pr checks` and unresolved non-outdated Copilot review threads. Never merge before all checks succeed **and** Copilot has actually submitted a review, including a no-comments review.
+
+If CI fails, inspect the failed run logs, fix and push, then restart the wait. If after roughly 30 minutes Copilot has neither reviewed nor has a pending review request, stop and ask whether to merge without it; never silently skip the Copilot wait.
+
+## Phase 9 — Address Copilot feedback
+
+For every unresolved Copilot thread:
+
+- Apply valid actionable feedback, commit it, reply, and resolve the thread.
+- For questionable feedback, use the codebase to disambiguate; otherwise ask only when necessary.
+- For invalid feedback, reply with a concise rationale and resolve it.
+
+Push fixes and return to Phase 8 until CI is green and no Copilot thread remains. Stop for a human decision if the same thread loops more than three times.
+
+## Phase 10 — Merge
+
+Merge with squash and delete the branch only when CI is successful, Copilot has posted a review, and every Copilot comment has been answered and resolved. Do not force-merge. If branch protection requires additional approvals or admin action, report the state and stop.
+
+## Phase 11 — Close and report
+
+Verify that `Closes #<number>` closed the issue. If it did not, close it with a completion comment. Report: issue, PR link, commits, CI status, Copilot threads resolved/total, and merged/closed status.
+
+## Phase 12 — Return to the default branch
+
+After merge, switch to the default branch, fast-forward it, and delete the local feature branch when safe.
+
+## Hard stops
+
+Stop and surface the exact next human action when the issue is already closed or actively owned, branch protection blocks merging, a Copilot thread loops more than three times, tests require disabling a check, or the issue needs a product/design decision that the repository cannot answer.

--- a/codex/ship-issue/SKILL.md
+++ b/codex/ship-issue/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: ship-issue
+description: Ship a GitHub issue end-to-end by reusing the source workflow under `claude/ship-issue`: implement, adversarially review and test, open a PR, address Copilot feedback, merge, and close the issue. Use when given a GitHub issue URL and asked to implement and ship it.
+metadata:
+  short-description: Ship a GitHub issue through merge
+---
+
+# Ship Issue
+
+Use this skill when the user gives a GitHub issue URL and asks to implement and ship it through a merged PR.
+
+This is a thin Codex wrapper around `claude/ship-issue/skills/ship-issue/SKILL.md`. Reuse the source workflow rather than maintaining a divergent copy.
+
+## Source Material
+
+- Source skill: `claude/ship-issue/skills/ship-issue/SKILL.md`
+- Source directory: `claude/ship-issue/skills/ship-issue/`
+
+Read the source workflow before acting and load only needed supporting files.
+
+## Codex Adaptation
+
+1. Resolve the issue URL, read the issue, explore the target repository, create a conventional feature branch, implement, and run the project’s narrowest relevant quality gates.
+2. Run Phase 5 adversarial review and Phase 6 adversarial manual testing. Use native Codex subagents if capacity permits; otherwise perform each adversarial pass inline with the source prompts and acceptance criteria. Do not omit either pass.
+3. Open the PR, request Copilot review where available, and poll at a 5–10 minute interval for both successful CI and a posted Copilot review. Address every valid thread and rerun the wait loop after fixes.
+4. Merge only when all source conditions hold. Verify the issue closes, return to the default branch, and provide the source skill’s terse final report.
+
+## Codex Notes
+
+- Ignore Claude-only frontmatter and runtime wiring such as `allowed-tools`, `user-invocable`, and `$ARGUMENTS`.
+- The user’s request to ship the issue authorizes normal branch, commit, push, PR, review-response, merge, and issue-close actions in the target repository. Ask only for ambiguity or an authority the source workflow identifies as a hard stop.
+- Do not suppress quality checks or force a merge.
+- If a networked command fails because of sandbox restrictions, rerun it with escalation and a concise justification.
+- After each state-changing step, inspect the relevant GitHub or git state before continuing.

--- a/plugins/ship-issue/.codex-plugin/plugin.json
+++ b/plugins/ship-issue/.codex-plugin/plugin.json
@@ -1,0 +1,30 @@
+{
+  "name": "ship-issue",
+  "version": "1.0.0",
+  "description": "Take a GitHub issue from implementation through adversarial review and testing, PR, CI and Copilot review, merge, and closure.",
+  "author": {
+    "name": "Smykla Skalski Labs"
+  },
+  "homepage": "https://github.com/smykla-skalski/sai",
+  "repository": "https://github.com/smykla-skalski/sai",
+  "license": "MIT",
+  "keywords": ["codex", "github", "issues", "pull-request", "ci", "copilot", "automation"],
+  "skills": "../../codex/ship-issue",
+  "interface": {
+    "displayName": "Ship Issue",
+    "shortDescription": "Ship a GitHub issue through merge",
+    "longDescription": "Ship Issue from the SAI Codex collection.",
+    "developerName": "SAI",
+    "category": "Developer Tools",
+    "capabilities": ["Interactive"],
+    "websiteURL": "https://github.com/smykla-skalski/sai",
+    "privacyPolicyURL": "https://github.com/smykla-skalski/sai/blob/main/README.md",
+    "termsOfServiceURL": "https://github.com/smykla-skalski/sai/blob/main/LICENSE",
+    "defaultPrompt": [
+      "Use $ship-issue for this task.",
+      "Open the Ship Issue skill and apply it to the current request.",
+      "Run the Ship Issue workflow and summarize the outcome."
+    ],
+    "brandColor": "#2563EB"
+  }
+}


### PR DESCRIPTION
## Summary

Add the Ship Issue workflow to the Claude and Codex marketplaces.

- package the Claude source skill and register it in the Claude marketplace
- add the Codex wrapper, package manifest, and Codex marketplace entry
- document installation in the repository README

## Validation

- JSON manifests parse with `python3 -m json.tool`
- `git diff --check` passes

Claude CLI smoke testing is blocked by an expired local OAuth session; the plugin validator is blocked because PyYAML is not installed.